### PR TITLE
Fix for resource leak of file handle in loom_shell and namespace collision between Eigen and OpenCV Mat

### DIFF
--- a/vx_ext_cv/OpenCV_AddWeighted.cpp
+++ b/vx_ext_cv/OpenCV_AddWeighted.cpp
@@ -157,7 +157,7 @@ vx_status VX_CALLBACK CV_AddWeighted_Kernel(vx_node node, const vx_reference *pa
 	vx_image image_out = (vx_image) parameters[5];
 	vx_scalar Dtype = (vx_scalar) parameters[6];
 
-	Mat *mat_1, *mat_2, bl;
+	cv::Mat  *mat_1, *mat_2, bl;
 	double aplha, beta, gamma;
 	int dtype;
 	vx_float32 value = 0;
@@ -178,7 +178,7 @@ vx_status VX_CALLBACK CV_AddWeighted_Kernel(vx_node node, const vx_reference *pa
 	//Compute using OpenCV
 	cv::addWeighted(*mat_1, aplha, *mat_2, beta, gamma, bl, dtype);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_BRISK_detector.cpp
+++ b/vx_ext_cv/OpenCV_BRISK_detector.cpp
@@ -138,7 +138,7 @@ static vx_status VX_CALLBACK CV_brisk_detector_Kernel(vx_node node, const vx_ref
 	vx_scalar OCTAVES = (vx_scalar) parameters[4];
 	vx_scalar SCALE = (vx_scalar) parameters[5];
 
-	Mat *mat, *mask_mat, Img;
+	cv::Mat  *mat, *mask_mat, Img;
 	int thresh, octaves;
 	float patternscale;
 	vx_float32 FloatValue = 0;
@@ -154,8 +154,8 @@ static vx_status VX_CALLBACK CV_brisk_detector_Kernel(vx_node node, const vx_ref
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mask_mat, mask));
 
 	//Compute using OpenCV
-	vector<KeyPoint> key_points;
-	Ptr<Feature2D> brisk = BRISK::create(thresh, octaves, patternscale);
+	vector<cv::KeyPoint> key_points;
+	cv::Ptr<cv::Feature2D> brisk = cv::BRISK::create(thresh, octaves, patternscale);
 	brisk->detect(*mat, key_points, *mask_mat);
 
 	//Converting OpenCV Keypoints to OpenVX Keypoints

--- a/vx_ext_cv/OpenCV_Blur.cpp
+++ b/vx_ext_cv/OpenCV_Blur.cpp
@@ -176,7 +176,7 @@ static vx_status VX_CALLBACK CV_Blur_Kernel(vx_node node, const vx_reference *pa
 	vx_scalar A_Y = (vx_scalar) parameters[5];
 	vx_scalar BORDER = (vx_scalar) parameters[6];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int W, H, a_x, a_y, border;
 	vx_int32 value = 0;
 
@@ -192,12 +192,12 @@ static vx_status VX_CALLBACK CV_Blur_Kernel(vx_node node, const vx_reference *pa
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
-	Point point;
+	cv::Point point;
 	point.x = a_x;
 	point.y = a_y;
-	cv::blur(*mat, bl, Size(W, H), point, border);
+	cv::blur(*mat, bl, cv::Size(W, H), point, border);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_Boxfilter.cpp
+++ b/vx_ext_cv/OpenCV_Boxfilter.cpp
@@ -182,7 +182,7 @@ static vx_status VX_CALLBACK CV_Boxfilter_Kernel(vx_node node, const vx_referenc
 	vx_scalar NORM = (vx_scalar) parameters[7];
 	vx_scalar BORDER = (vx_scalar) parameters[8];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int ddepth, W, H, a_x = -1, a_y = -1, border = 4;
 
 	vx_int32 value = 0;
@@ -202,14 +202,14 @@ static vx_status VX_CALLBACK CV_Boxfilter_Kernel(vx_node node, const vx_referenc
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
-	Point point;
+	cv::Point point;
 	bool Normalized;
 	if (norm == vx_true_e) Normalized = true; else Normalized = false;
 	point.x = a_x;
 	point.y = a_y;
-	cv::boxFilter(*mat, bl, ddepth, Size(W, H), point, Normalized, border);
+	cv::boxFilter(*mat, bl, ddepth, cv::Size(W, H), point, Normalized, border);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_Canny.cpp
+++ b/vx_ext_cv/OpenCV_Canny.cpp
@@ -146,7 +146,7 @@ static vx_status VX_CALLBACK CV_Canny_Kernel(vx_node node, const vx_reference *p
 	vx_scalar APERSIZE = (vx_scalar) parameters[4];
 	vx_scalar L2GRAD = (vx_scalar) parameters[5];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 
 	float threshold1, threshold2;
 	int aperture_size;
@@ -169,7 +169,7 @@ static vx_status VX_CALLBACK CV_Canny_Kernel(vx_node node, const vx_reference *p
 	if (l2grad == vx_true_e) L2_Gradient = true; else L2_Gradient = false;
 	cv::Canny(*mat, bl, threshold1, threshold2, aperture_size, L2_Gradient);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_FAST_feature_detector.cpp
+++ b/vx_ext_cv/OpenCV_FAST_feature_detector.cpp
@@ -113,7 +113,7 @@ static vx_status VX_CALLBACK CV_FAST_detector_Kernel(vx_node node, const vx_refe
 	vx_array array = (vx_array) parameters[1];
 	vx_scalar Threshold = (vx_scalar) parameters[2];
 	vx_scalar NonMAXSuppression = (vx_scalar) parameters[3];
-	Mat *mat, Img;
+	cv::Mat  *mat, Img;
 	vx_int32 value = 0;
 	vx_bool value_b, nonmax;
 	int threshold = 0;
@@ -126,7 +126,7 @@ static vx_status VX_CALLBACK CV_FAST_detector_Kernel(vx_node node, const vx_refe
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
-	vector<KeyPoint> key_points;
+	vector<cv::KeyPoint> key_points;
 	bool nonmax_bool = false;
 	if (nonmax == vx_true_e) nonmax_bool = true; else nonmax_bool = false;
 	cv::FAST(*mat, key_points, threshold, nonmax_bool);

--- a/vx_ext_cv/OpenCV_Gaussianblur.cpp
+++ b/vx_ext_cv/OpenCV_Gaussianblur.cpp
@@ -158,7 +158,7 @@ static vx_status VX_CALLBACK CV_Gaussianblur_Kernel(vx_node node, const vx_refer
 	vx_scalar scalar_1 = (vx_scalar) parameters[5];
 	vx_scalar scalar_2 = (vx_scalar) parameters[6];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int W, H, Border;
 	float Sigma_X, Sigma_Y;
 	vx_int32 value = 0;
@@ -176,9 +176,9 @@ static vx_status VX_CALLBACK CV_Gaussianblur_Kernel(vx_node node, const vx_refer
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
-	cv::GaussianBlur(*mat, bl, Size(W, H), Sigma_X, Sigma_Y, Border);
+	cv::GaussianBlur(*mat, bl, cv::Size(W, H), Sigma_X, Sigma_Y, Border);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_Good_Features_to_Track_detector.cpp
+++ b/vx_ext_cv/OpenCV_Good_Features_to_Track_detector.cpp
@@ -176,7 +176,7 @@ static vx_status VX_CALLBACK CV_good_feature_detector_Kernel(vx_node node, const
 	vx_scalar USEHARRISDETECTOR = (vx_scalar) parameters[7];
 	vx_scalar K = (vx_scalar) parameters[8];
 
-	Mat *mat, *mask_mat, Img;
+	cv::Mat  *mat, *mask_mat, Img;
 	int maxCorners, blockSize;
 	float qualityLevel, minDistance, k;
 	vx_float32 FloatValue = 0;
@@ -196,7 +196,7 @@ static vx_status VX_CALLBACK CV_good_feature_detector_Kernel(vx_node node, const
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mask_mat, mask));
 
 	//Compute using OpenCV
-	vector<Point2f> Points2;
+	vector<cv::Point2f> Points2;
 	bool useHarrisDetector;
 	if (useHarris == 1) useHarrisDetector = true; else useHarrisDetector = false;
 	cv::goodFeaturesToTrack(*mat, Points2, maxCorners, qualityLevel, minDistance, *mask_mat, blockSize, useHarrisDetector, k); ////Compute using OpenCV

--- a/vx_ext_cv/OpenCV_Laplacian.cpp
+++ b/vx_ext_cv/OpenCV_Laplacian.cpp
@@ -158,7 +158,7 @@ static vx_status VX_CALLBACK CV_Laplacian_Kernel(vx_node node, const vx_referenc
 	vx_scalar DELTA = (vx_scalar) parameters[5];
 	vx_scalar BORDER = (vx_scalar) parameters[6];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int ddepth, ksize, Border;
 	float scale, delta;
 	vx_int32 value = 0;
@@ -178,7 +178,7 @@ static vx_status VX_CALLBACK CV_Laplacian_Kernel(vx_node node, const vx_referenc
 	//Compute using OpenCV
 	cv::Laplacian(*mat, bl, ddepth, ksize, scale, delta, Border);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_MSER_feature_detector.cpp
+++ b/vx_ext_cv/OpenCV_MSER_feature_detector.cpp
@@ -207,8 +207,8 @@ static vx_status VX_CALLBACK CV_MSER_feature_detector_Kernel(vx_node node, const
 	vx_scalar MINMAR = (vx_scalar) parameters[10];
 	vx_scalar EDGEBLUR = (vx_scalar) parameters[11];
 
-	Mat *mat, *mask_mat, Img;
-	vector<KeyPoint> key_points;
+	cv::Mat  *mat, *mask_mat, Img;
+	vector<cv::KeyPoint> key_points;
 	int delta, min_area, max_area, max_evolution, edge_blur_size;
 	float max_variation, min_diversity, area_threshold, min_margin;
 	vx_float32 FloatValue = 0;
@@ -230,7 +230,7 @@ static vx_status VX_CALLBACK CV_MSER_feature_detector_Kernel(vx_node node, const
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mask_mat, mask));
 
 	//Compute using OpenCV
-	Ptr<Feature2D> mser = MSER::create(delta, min_area, max_area, max_variation, min_diversity, max_evolution, area_threshold, min_margin, edge_blur_size);
+	cv::Ptr<cv::Feature2D> mser = cv::MSER::create(delta, min_area, max_area, max_variation, min_diversity, max_evolution, area_threshold, min_margin, edge_blur_size);
 	mser->detect(*mat, key_points, *mask_mat);
 
 	//OpenCV 2.4.11 Call 

--- a/vx_ext_cv/OpenCV_Medianblur.cpp
+++ b/vx_ext_cv/OpenCV_Medianblur.cpp
@@ -130,7 +130,7 @@ static vx_status VX_CALLBACK CV_MedianBlur_Kernel(vx_node node, const vx_referen
 	vx_image image_out = (vx_image) parameters[1];
 	vx_scalar scalar = (vx_scalar) parameters[2];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int Ksize;
 	vx_int32 value = 0;
 
@@ -144,7 +144,7 @@ static vx_status VX_CALLBACK CV_MedianBlur_Kernel(vx_node node, const vx_referen
 	//Compute using OpenCV
 	cv::medianBlur(*mat, bl, Ksize);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_ORB_detector.cpp
+++ b/vx_ext_cv/OpenCV_ORB_detector.cpp
@@ -196,10 +196,10 @@ static vx_status VX_CALLBACK CV_orb_detector_Kernel(vx_node node, const vx_refer
 	vx_scalar SCORETYPE = (vx_scalar) parameters[9];
 	vx_scalar PATCHSIZE = (vx_scalar) parameters[10];
 
-	Mat *mat, *mask_mat, Img;
+	cv::Mat  *mat, *mask_mat, Img;
 	int nFeatures, nLevels, edgeThreshold, firstLevel, WTA_K, scoreType, patchSize;
 	float  ScaleFactor;
-	vector<KeyPoint> key_points;
+	vector<cv::KeyPoint> key_points;
 	vx_int32 value = 0;
 	vx_float32 value_F = 0;
 
@@ -218,7 +218,7 @@ static vx_status VX_CALLBACK CV_orb_detector_Kernel(vx_node node, const vx_refer
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mask_mat, mask));
 
 	//Compute using OpenCV
-	Ptr<Feature2D> orb = ORB::create(nFeatures, ScaleFactor, nLevels, edgeThreshold, firstLevel, WTA_K, scoreType, patchSize);
+	cv::Ptr<cv::Feature2D> orb = cv::ORB::create(nFeatures, ScaleFactor, nLevels, edgeThreshold, firstLevel, WTA_K, scoreType, patchSize);
 	orb->detect(*mat, key_points, *mask_mat);
 
 	//OpenCV 2.4 Call

--- a/vx_ext_cv/OpenCV_SIFT_Compute.cpp
+++ b/vx_ext_cv/OpenCV_SIFT_Compute.cpp
@@ -175,9 +175,9 @@ static vx_status VX_CALLBACK CV_SIFT_Compute_Kernel(vx_node node, const vx_refer
 	vx_scalar EdgeTHRESHOLD = (vx_scalar) parameters[7];
 	vx_scalar SIGMA = (vx_scalar) parameters[8];
 
-	Mat *mat, *mask_mat, Img;
-	std::vector<KeyPoint> key_points;
-	Mat Desp;
+	cv::Mat  *mat, *mask_mat, Img;
+	std::vector<cv::KeyPoint> key_points;
+	cv::Mat Desp;
 	vx_float32 FloatValue = 0;
 	vx_int32 value = 0;
 	float CTHRESHOLD, ETHRESHOLD, Sigma;
@@ -195,7 +195,7 @@ static vx_status VX_CALLBACK CV_SIFT_Compute_Kernel(vx_node node, const vx_refer
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mask_mat, mask));
 
 	//Compute using OpenCV
-	Ptr<Feature2D> sift = xfeatures2d::SIFT::create(NFEATURES, NOctaveLayers, CTHRESHOLD, ETHRESHOLD, Sigma);
+	cv::Ptr<cv::Feature2D> sift = xfeatures2d::SIFT::create(NFEATURES, NOctaveLayers, CTHRESHOLD, ETHRESHOLD, Sigma);
 	sift->detectAndCompute(*mat, *mask_mat, key_points, Desp);
 
 	//Converting OpenCV Keypoints to OpenVX Keypoints

--- a/vx_ext_cv/OpenCV_SIFT_Detect.cpp
+++ b/vx_ext_cv/OpenCV_SIFT_Detect.cpp
@@ -162,8 +162,8 @@ static vx_status VX_CALLBACK CV_SIFT_Detect_Kernel(vx_node node, const vx_refere
 	vx_scalar EdgeTHRESHOLD = (vx_scalar) parameters[6];
 	vx_scalar SIGMA = (vx_scalar) parameters[7];
 
-	Mat *mat, *mask_mat, Img;
-	vector<KeyPoint> key_points;
+	cv::Mat  *mat, *mask_mat, Img;
+	vector<cv::KeyPoint> key_points;
 	vx_float32 FloatValue = 0;
 	vx_int32 value = 0;
 	float CTHRESHOLD, ETHRESHOLD, Sigma;
@@ -181,7 +181,7 @@ static vx_status VX_CALLBACK CV_SIFT_Detect_Kernel(vx_node node, const vx_refere
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mask_mat, mask));
 
 	//Compute using OpenCV
-	Ptr<Feature2D> sift = xfeatures2d::SIFT::create(NFEATURES, NOctaveLayers, CTHRESHOLD, ETHRESHOLD, Sigma);
+	cv::Ptr<cv::Feature2D> sift = xfeatures2d::SIFT::create(NFEATURES, NOctaveLayers, CTHRESHOLD, ETHRESHOLD, Sigma);
 	sift->detect(*mat, key_points, *mask_mat);
 
 	//Converting OpenCV Keypoints to OpenVX Keypoints

--- a/vx_ext_cv/OpenCV_SURF_Compute.cpp
+++ b/vx_ext_cv/OpenCV_SURF_Compute.cpp
@@ -171,7 +171,7 @@ static vx_status VX_CALLBACK CV_SURF_Compute_Kernel(vx_node node, const vx_refer
 	vx_scalar EXTENDED = (vx_scalar) parameters[7];
 	vx_scalar UPRIGHT = (vx_scalar) parameters[8];
 
-	Mat *mat, *mask_mat, Img;
+	cv::Mat  *mat, *mask_mat, Img;
 	vx_float32 FloatValue = 0;
 	vx_int32 value = 0;
 	vx_bool extend, upright, value_b;
@@ -193,9 +193,9 @@ static vx_status VX_CALLBACK CV_SURF_Compute_Kernel(vx_node node, const vx_refer
 	bool extended_B, upright_b;
 	if (extend == vx_true_e) extended_B = true; else extended_B = false;
 	if (upright == vx_true_e) upright_b = true; else upright_b = false;
-	vector<KeyPoint> key_points;
-	Mat Desp;
-	Ptr<Feature2D> surf = xfeatures2d::SURF::create(HessianThreshold, NOctaves, NOctaveLayers);
+	vector<cv::KeyPoint> key_points;
+	cv::Mat Desp;
+	cv::Ptr<cv::Feature2D> surf = xfeatures2d::SURF::create(HessianThreshold, NOctaves, NOctaveLayers);
 	surf->detectAndCompute(*mat, *mask_mat, key_points, Desp);
 
 	//Converting OpenCV Keypoints to OpenVX Keypoints

--- a/vx_ext_cv/OpenCV_SURF_Detect.cpp
+++ b/vx_ext_cv/OpenCV_SURF_Detect.cpp
@@ -138,7 +138,7 @@ static vx_status VX_CALLBACK CV_SURF_Detect_Kernel(vx_node node, const vx_refere
 	vx_scalar nOctaves = (vx_scalar) parameters[4];
 	vx_scalar nOctaveLayers = (vx_scalar) parameters[5];
 
-	Mat *mat, *mask_mat, Img;
+	cv::Mat  *mat, *mask_mat, Img;
 	vx_uint32 width = 0;
 	vx_uint32 height = 0;
 
@@ -158,8 +158,8 @@ static vx_status VX_CALLBACK CV_SURF_Detect_Kernel(vx_node node, const vx_refere
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mask_mat, mask));
 
 	//Compute using OpenCV
-	vector<KeyPoint> key_points;
-	Ptr<Feature2D> surf = xfeatures2d::SURF::create(HessianThreshold, NOctaves, NOctaveLayers);
+	vector<cv::KeyPoint> key_points;
+	cv::Ptr<cv::Feature2D> surf = xfeatures2d::SURF::create(HessianThreshold, NOctaves, NOctaveLayers);
 	surf->detect(*mat, key_points, *mask_mat);
 
 	//Converting OpenCV Keypoints to OpenVX Keypoints

--- a/vx_ext_cv/OpenCV_Scharr.cpp
+++ b/vx_ext_cv/OpenCV_Scharr.cpp
@@ -170,7 +170,7 @@ static vx_status VX_CALLBACK CV_Scharr_Kernel(vx_node node, const vx_reference *
 	vx_scalar Delta = (vx_scalar) parameters[6];
 	vx_scalar Bordertype = (vx_scalar) parameters[7];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int ddepth, dx, dy, bordertype;
 	double scale, delta;
 	vx_int32 value = 0;
@@ -191,7 +191,7 @@ static vx_status VX_CALLBACK CV_Scharr_Kernel(vx_node node, const vx_reference *
 	//Compute using OpenCV
 	cv::Scharr(*mat, bl, ddepth, dx, dy, scale, delta, bordertype);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_Sobel.cpp
+++ b/vx_ext_cv/OpenCV_Sobel.cpp
@@ -182,7 +182,7 @@ static vx_status VX_CALLBACK CV_Sobel_Kernel(vx_node node, const vx_reference *p
 	vx_scalar Delta = (vx_scalar) parameters[7];
 	vx_scalar Bordertype = (vx_scalar) parameters[8];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int ddepth, dx, dy, ksize, bordertype;
 	double scale, delta;
 	vx_int32 value = 0;
@@ -204,7 +204,7 @@ static vx_status VX_CALLBACK CV_Sobel_Kernel(vx_node node, const vx_reference *p
 	//Compute using OpenCV
 	cv::Sobel(*mat, bl, ddepth, dx, dy, ksize, scale, delta, bordertype);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_Star_feature_detector.cpp
+++ b/vx_ext_cv/OpenCV_Star_feature_detector.cpp
@@ -160,10 +160,10 @@ static vx_status VX_CALLBACK CV_star_feature_detector_Kernel(vx_node node, const
 	vx_scalar lineThresholdB = (vx_scalar) parameters[6];
 	vx_scalar suppressN = (vx_scalar) parameters[7];
 
-	Mat *mat, *mask_mat, Img;
+	cv::Mat  *mat, *mask_mat, Img;
 	vx_uint32 width = 0;
 	vx_uint32 height = 0;
-	vector<KeyPoint> key_points;
+	vector<cv::KeyPoint> key_points;
 	int maxSize, responseThreshold, lineThresholdProjected, lineThresholdBinarized, suppressNonmaxSize;
 	vx_int32 value = 0;
 
@@ -179,7 +179,7 @@ static vx_status VX_CALLBACK CV_star_feature_detector_Kernel(vx_node node, const
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mask_mat, mask));
 
 	//Compute using OpenCV
-	Ptr<Feature2D> star = xfeatures2d::StarDetector::create(maxSize, responseThreshold, lineThresholdProjected, lineThresholdBinarized, suppressNonmaxSize);
+	cv::Ptr<cv::Feature2D> star = xfeatures2d::StarDetector::create(maxSize, responseThreshold, lineThresholdProjected, lineThresholdBinarized, suppressNonmaxSize);
 	star->detect(*mat, key_points, *mask_mat);
 
 	//Converting OpenCV Keypoints to OpenVX Keypoints

--- a/vx_ext_cv/OpenCV_Tunnel.h
+++ b/vx_ext_cv/OpenCV_Tunnel.h
@@ -30,6 +30,9 @@ THE SOFTWARE.
 #endif
 
 #include"VX/vx.h"
+#if defined(VX_VERSION_1_1)
+#include <VX/vx_compatibility.h>
+#endif
 #include"vx_ext_cv.h"
 
 #include<stdio.h>
@@ -40,22 +43,21 @@ THE SOFTWARE.
 #include<algorithm>
 #include<functional>
 
-using namespace cv;
 using namespace std;
 
 #define STATUS_ERROR_CHECK(call){vx_status status = call; if(status!= VX_SUCCESS) return status;} 
 #define PARAM_ERROR_CHECK(call){vx_status status = call; if(status!= VX_SUCCESS) goto exit;}
 #define MAX_KERNELS 100
 
-int VX_to_CV_Image(Mat**, vx_image);
-int VX_to_CV_MATRIX(Mat**, vx_matrix);
+VX_API_ENTRY int VX_API_CALL VX_to_CV_Image(cv::Mat**, vx_image);
+VX_API_ENTRY int VX_API_CALL VX_to_CV_MATRIX(cv::Mat**, vx_matrix);
 
-int CV_to_VX_Pyramid(vx_pyramid, vector<Mat>);
-int CV_to_VX_Image(vx_image, Mat*);
+VX_API_ENTRY int VX_API_CALL CV_to_VX_Pyramid(vx_pyramid, vector<cv::Mat>);
+VX_API_ENTRY int VX_API_CALL CV_to_VX_Image(vx_image, cv::Mat*);
 
-int CV_to_VX_keypoints(vector<KeyPoint>, vx_array);
-int CVPoints2f_to_VX_keypoints(vector<Point2f>, vx_array);
-int CV_DESP_to_VX_DESP(Mat, vx_array, int);
+VX_API_ENTRY int VX_API_CALL CV_to_VX_keypoints(vector<cv::KeyPoint>, vx_array);
+VX_API_ENTRY int VX_API_CALL CVPoints2f_to_VX_keypoints(vector<cv::Point2f>, vx_array);
+VX_API_ENTRY int VX_API_CALL CV_DESP_to_VX_DESP(cv::Mat, vx_array, int);
 
 int match_vx_image_parameters(vx_image, vx_image);
 

--- a/vx_ext_cv/OpenCV_absdiff.cpp
+++ b/vx_ext_cv/OpenCV_absdiff.cpp
@@ -109,7 +109,7 @@ static vx_status VX_CALLBACK CV_absdiff_Kernel(vx_node node, const vx_reference 
 	vx_image image_1 = (vx_image) parameters[0];
 	vx_image image_2 = (vx_image) parameters[1];
 	vx_image image_out = (vx_image) parameters[2];
-	Mat *mat_1, *mat_2, bl;
+	cv::Mat  *mat_1, *mat_2, bl;
 
 	//Converting VX Images to OpenCV Mat
 	STATUS_ERROR_CHECK(match_vx_image_parameters(image_1, image_2));
@@ -120,7 +120,7 @@ static vx_status VX_CALLBACK CV_absdiff_Kernel(vx_node node, const vx_reference 
 	//Compute using OpenCV
 	cv::absdiff(*mat_1, *mat_2, bl);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_adaptiveThreshold.cpp
+++ b/vx_ext_cv/OpenCV_adaptiveThreshold.cpp
@@ -155,7 +155,7 @@ vx_status VX_CALLBACK CV_adaptiveThreshold_Kernel(vx_node node, const vx_referen
 	vx_scalar BLOCKSIZE = (vx_scalar)parameters[5];
 	vx_scalar C = (vx_scalar)parameters[6];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 
 	int adaptiveMethod, thresholdType, blockSize;
 	float maxValue, c;
@@ -176,7 +176,7 @@ vx_status VX_CALLBACK CV_adaptiveThreshold_Kernel(vx_node node, const vx_referen
 	//Compute using OpenCV
 	cv::adaptiveThreshold(*mat, bl, maxValue, adaptiveMethod, thresholdType, blockSize, c);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_add.cpp
+++ b/vx_ext_cv/OpenCV_add.cpp
@@ -108,10 +108,10 @@ vx_status VX_CALLBACK CV_add_Kernel(vx_node node, const vx_reference *parameters
 	vx_image image_2 = (vx_image) parameters[1];
 	vx_image image_out = (vx_image) parameters[2];
 
-	Mat *mat_1, *mat_2, bl;
+	cv::Mat  *mat_1, *mat_2, bl;
 	vx_int32 value = 0;
 	
-	//Converting VX Image to OpenCV Mat 1
+	//Converting VX Image to OpenCV cv::Mat 1
 	STATUS_ERROR_CHECK(match_vx_image_parameters(image_1, image_2));
 	STATUS_ERROR_CHECK(match_vx_image_parameters(image_1, image_out));
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat_1, image_1));
@@ -120,7 +120,7 @@ vx_status VX_CALLBACK CV_add_Kernel(vx_node node, const vx_reference *parameters
 	//Compute using OpenCV
 	cv::add(*mat_1, *mat_2, bl);
 	
-	//Converting OpenCV Mat into VX Image	
+	//Converting OpenCV cv::Mat into VX Image	
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_bilateralFilter.cpp
+++ b/vx_ext_cv/OpenCV_bilateralFilter.cpp
@@ -145,7 +145,7 @@ vx_status VX_CALLBACK CV_bilateralFilter_Kernel(vx_node node, const vx_reference
 	vx_scalar SIGMA_S = (vx_scalar) parameters[4];
 	vx_scalar BORDER = (vx_scalar) parameters[5];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int  d, Border;
 	float Sigma_Color, Sigma_Space;
 
@@ -165,7 +165,7 @@ vx_status VX_CALLBACK CV_bilateralFilter_Kernel(vx_node node, const vx_reference
 	//Compute using OpenCV
 	cv::bilateralFilter(*mat, bl, d, Sigma_Color, Sigma_Space, Border);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_bitwise_and.cpp
+++ b/vx_ext_cv/OpenCV_bitwise_and.cpp
@@ -109,9 +109,9 @@ vx_status VX_CALLBACK CV_bitwise_and_Kernel(vx_node node, const vx_reference *pa
 	vx_image image_2 = (vx_image)parameters[1];
 	vx_image image_out = (vx_image)parameters[2];
 
-	Mat *mat_1, *mat_2, bl;
+	cv::Mat  *mat_1, *mat_2, bl;
 
-	//Converting VX Image to OpenCV Mat 1
+	//Converting VX Image to OpenCV cv::Mat 1
 	STATUS_ERROR_CHECK(match_vx_image_parameters(image_1, image_2));
 	STATUS_ERROR_CHECK(match_vx_image_parameters(image_1, image_out));
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat_1, image_1));
@@ -120,7 +120,7 @@ vx_status VX_CALLBACK CV_bitwise_and_Kernel(vx_node node, const vx_reference *pa
 	//Compute using OpenCV
 	cv::bitwise_and(*mat_1, *mat_2, bl);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_bitwise_not.cpp
+++ b/vx_ext_cv/OpenCV_bitwise_not.cpp
@@ -97,16 +97,16 @@ vx_status VX_CALLBACK CV_bitwise_not_Kernel(vx_node node, const vx_reference *pa
 	vx_image image_in = (vx_image) parameters[0];
 	vx_image image_out = (vx_image) parameters[1];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 
-	//Converting VX Image to OpenCV Mat 1
+	//Converting VX Image to OpenCV cv::Mat 1
 	STATUS_ERROR_CHECK(match_vx_image_parameters(image_in, image_out));
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
 	cv::bitwise_not(*mat, bl);
 
-	//Converting OpenCV Mat into VX Image	
+	//Converting OpenCV cv::Mat into VX Image	
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_bitwise_or.cpp
+++ b/vx_ext_cv/OpenCV_bitwise_or.cpp
@@ -109,9 +109,9 @@ vx_status VX_CALLBACK CV_bitwise_or_Kernel(vx_node node, const vx_reference *par
 	vx_image image_1 = (vx_image) parameters[0];
 	vx_image image_2 = (vx_image) parameters[1];
 	vx_image image_out = (vx_image) parameters[2];
-	Mat *mat_1, *mat_2, bl;
+	cv::Mat  *mat_1, *mat_2, bl;
 
-	//Converting VX Image to OpenCV Mat 1
+	//Converting VX Image to OpenCV cv::Mat 1
 	STATUS_ERROR_CHECK(match_vx_image_parameters(image_1, image_2));
 	STATUS_ERROR_CHECK(match_vx_image_parameters(image_1, image_out));
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat_1, image_1));
@@ -120,7 +120,7 @@ vx_status VX_CALLBACK CV_bitwise_or_Kernel(vx_node node, const vx_reference *par
 	//Compute using OpenCV
 	cv::bitwise_or(*mat_1, *mat_2, bl);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_bitwise_xor.cpp
+++ b/vx_ext_cv/OpenCV_bitwise_xor.cpp
@@ -110,9 +110,9 @@ vx_status VX_CALLBACK CV_bitwise_xor_Kernel(vx_node node, const vx_reference *pa
 	vx_image image_2 = (vx_image) parameters[1];
 	vx_image image_out = (vx_image) parameters[2];
 
-	Mat *mat_1, *mat_2, bl;
+	cv::Mat  *mat_1, *mat_2, bl;
 
-	//Converting VX Image to OpenCV Mat 1
+	//Converting VX Image to OpenCV cv::Mat 1
 	STATUS_ERROR_CHECK(match_vx_image_parameters(image_1, image_2));
 	STATUS_ERROR_CHECK(match_vx_image_parameters(image_1, image_out));
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat_1, image_1));
@@ -121,7 +121,7 @@ vx_status VX_CALLBACK CV_bitwise_xor_Kernel(vx_node node, const vx_reference *pa
 	//Compute using OpenCV
 	cv::bitwise_xor(*mat_1, *mat_2, bl);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_brisk_compute.cpp
+++ b/vx_ext_cv/OpenCV_brisk_compute.cpp
@@ -147,7 +147,7 @@ static vx_status VX_CALLBACK CV_brisk_compute_Kernel(vx_node node, const vx_refe
 	vx_scalar OCTAVES = (vx_scalar) parameters[5];
 	vx_scalar SCALE = (vx_scalar) parameters[6];
 
-	Mat *mat, *mask_mat, Img;
+	cv::Mat  *mat, *mask_mat, Img;
 	int thresh, octaves;
 	float patternscale;
 	vx_float32 FloatValue = 0;
@@ -163,9 +163,9 @@ static vx_status VX_CALLBACK CV_brisk_compute_Kernel(vx_node node, const vx_refe
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mask_mat, mask));
 
 	//Compute using OpenCV
-	vector<KeyPoint> key_points;
-	Mat desp;
-	Ptr<Feature2D> brisk = BRISK::create(thresh, octaves, patternscale);
+	vector<cv::KeyPoint> key_points;
+	cv::Mat desp;
+	cv::Ptr<cv::Feature2D> brisk = cv::BRISK::create(thresh, octaves, patternscale);
 	brisk->detectAndCompute(*mat, *mask_mat, key_points, desp);
 
 	//Converting OpenCV Keypoints/Descriptors to OpenVX Keypoints/Descriptors

--- a/vx_ext_cv/OpenCV_buildOpticalFlowPyramid.cpp
+++ b/vx_ext_cv/OpenCV_buildOpticalFlowPyramid.cpp
@@ -196,7 +196,7 @@ static vx_status VX_CALLBACK CV_buildOpticalFlowPyramid_Kernel(vx_node node, con
 	vx_scalar D_Border = (vx_scalar) parameters[7];
 	vx_scalar TRY_Reuse = (vx_scalar) parameters[8];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int W, H, WinSize, Pry_Border, derviBorder;
 	vx_bool WithDervi, try_reuse;
 	vx_int32 value = 0;
@@ -215,13 +215,13 @@ static vx_status VX_CALLBACK CV_buildOpticalFlowPyramid_Kernel(vx_node node, con
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
-	vector<Mat> pyramid_cv;
+	vector<cv::Mat> pyramid_cv;
 	bool WithDervi_b, try_reuse_b;
 	if (WithDervi == 1) WithDervi_b = true; else WithDervi_b = false;
 	if (try_reuse == 1) try_reuse_b = true; else try_reuse_b = false;
-	cv::buildOpticalFlowPyramid(*mat, pyramid_cv, Size(W, H), WinSize, WithDervi_b, Pry_Border, derviBorder, try_reuse_b);
+	cv::buildOpticalFlowPyramid(*mat, pyramid_cv, cv::Size(W, H), WinSize, WithDervi_b, Pry_Border, derviBorder, try_reuse_b);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Pyramid(pyramid_vx, pyramid_cv));
 
 	return status;

--- a/vx_ext_cv/OpenCV_buildPyramid.cpp
+++ b/vx_ext_cv/OpenCV_buildPyramid.cpp
@@ -134,7 +134,7 @@ static vx_status VX_CALLBACK CV_buildPyramid_Kernel(vx_node node, const vx_refer
 	vx_scalar scalar = (vx_scalar) parameters[2];
 	vx_scalar scalar1 = (vx_scalar) parameters[3];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int maxLevel, border;
 
 	vx_int32 value = 0;
@@ -147,10 +147,10 @@ static vx_status VX_CALLBACK CV_buildPyramid_Kernel(vx_node node, const vx_refer
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
-	vector<Mat> pyramid_cv;
+	vector<cv::Mat> pyramid_cv;
 	cv::buildPyramid(*mat, pyramid_cv, maxLevel, border);
 
-	//Converting OpenCV Vector Mat into VX Image
+	//Converting OpenCV Vector cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Pyramid(pyramid, pyramid_cv));
 
 	return status;

--- a/vx_ext_cv/OpenCV_compare.cpp
+++ b/vx_ext_cv/OpenCV_compare.cpp
@@ -121,7 +121,7 @@ static vx_status VX_CALLBACK CV_compare_Kernel(vx_node node, const vx_reference 
 	vx_image image_out = (vx_image) parameters[2];
 	vx_scalar CMPOP = (vx_scalar) parameters[3];
 
-	Mat *mat_1, *mat_2, bl;
+	cv::Mat  *mat_1, *mat_2, bl;
 	vx_int32 value = 0;
 	int cmpop;
 
@@ -137,7 +137,7 @@ static vx_status VX_CALLBACK CV_compare_Kernel(vx_node node, const vx_reference 
 	//Compute using OpenCV
 	cv::compare(*mat_1, *mat_2, bl, cmpop);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_convertScaleAbs.cpp
+++ b/vx_ext_cv/OpenCV_convertScaleAbs.cpp
@@ -121,7 +121,7 @@ static vx_status VX_CALLBACK CV_convertScaleAbs_Kernel(vx_node node, const vx_re
 	vx_image image_out = (vx_image)parameters[1];
 	vx_scalar ALPHA = (vx_scalar)parameters[2];
 	vx_scalar BETA = (vx_scalar)parameters[3];
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	double alpha, beta;
 	vx_float32 value = 0;
 
@@ -136,7 +136,7 @@ static vx_status VX_CALLBACK CV_convertScaleAbs_Kernel(vx_node node, const vx_re
 	//Compute using OpenCV
 	convertScaleAbs(*mat, bl, alpha, beta);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_cornerHarris.cpp
+++ b/vx_ext_cv/OpenCV_cornerHarris.cpp
@@ -146,7 +146,7 @@ static vx_status VX_CALLBACK CV_cornerHarris_Kernel(vx_node node, const vx_refer
 	vx_scalar KSIZE = (vx_scalar) parameters[3];
 	vx_scalar K = (vx_scalar) parameters[4];
 	vx_scalar BORDER = (vx_scalar) parameters[5];
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int blocksize, ksize, border;
 	float  k;
 	vx_int32 value = 0;
@@ -165,7 +165,7 @@ static vx_status VX_CALLBACK CV_cornerHarris_Kernel(vx_node node, const vx_refer
 	//Compute using OpenCV
 	cv::cornerHarris(*mat, bl, blocksize, ksize, k, border);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_cornerMinEigenVal.cpp
+++ b/vx_ext_cv/OpenCV_cornerMinEigenVal.cpp
@@ -133,7 +133,7 @@ static vx_status VX_CALLBACK CV_cornerMinEigenVal_Kernel(vx_node node, const vx_
 	vx_scalar KSIZE = (vx_scalar) parameters[3];
 	vx_scalar BORDER = (vx_scalar) parameters[4];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int blockSize, ksize, border;
 	vx_int32 value = 0;
 
@@ -149,7 +149,7 @@ static vx_status VX_CALLBACK CV_cornerMinEigenVal_Kernel(vx_node node, const vx_
 	//Compute using OpenCV
 	cv::cornerMinEigenVal(*mat, bl, blockSize, ksize, border);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_countNonZero.cpp
+++ b/vx_ext_cv/OpenCV_countNonZero.cpp
@@ -87,7 +87,7 @@ static vx_status VX_CALLBACK CV_countNonZero_Kernel(vx_node node, const vx_refer
 	vx_status status = VX_SUCCESS;
 	vx_image image_in = (vx_image) parameters[0];
 	vx_scalar scalar = (vx_scalar) parameters[1];
-	Mat *mat;
+	cv::Mat  *mat;
 	int NonZero;
 
 	//Converting VX Image to OpenCV Mat

--- a/vx_ext_cv/OpenCV_cvtColor.cpp
+++ b/vx_ext_cv/OpenCV_cvtColor.cpp
@@ -107,7 +107,7 @@ static vx_status VX_CALLBACK CV_cvtColor_Kernel(vx_node node, const vx_reference
 	vx_image image_in = (vx_image) parameters[0];
 	vx_image image_out = (vx_image) parameters[1];
 	vx_scalar scalar = (vx_scalar) parameters[2];
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int CODE;
 	vx_int32 value = 0;
 
@@ -121,7 +121,7 @@ static vx_status VX_CALLBACK CV_cvtColor_Kernel(vx_node node, const vx_reference
 	//Compute using OpenCV
 	cv::cvtColor(*mat, bl, CODE);// CODE have to be checked with OpenCV, the frame work will not check for invalid code
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_data_translator.cpp
+++ b/vx_ext_cv/OpenCV_data_translator.cpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 /************************************************************************************************************
 Converting CV Pyramid into an OpenVX Pyramid
 *************************************************************************************************************/
-int CV_to_VX_Pyramid(vx_pyramid pyramid_vx, vector<Mat> pyramid_cv)
+VX_API_ENTRY int VX_API_CALL CV_to_VX_Pyramid(vx_pyramid pyramid_vx, vector<cv::Mat> pyramid_cv)
 {
 	vx_status status = VX_SUCCESS;
 	vx_size Level_vx = 0; vx_uint32 width = 0; 	vx_uint32 height = 0; vx_int32 i;
@@ -41,7 +41,7 @@ int CV_to_VX_Pyramid(vx_pyramid pyramid_vx, vector<Mat> pyramid_cv)
 		{
 			vxAddLogEntry((vx_reference)pyramid_vx, VX_ERROR_INVALID_DIMENSION, "CV_to_VX_Pyramid ERROR: Pyramid Image Mismatch\n"); return VX_ERROR_INVALID_DIMENSION;
 		}
-		Mat* pyr_level;
+		cv::Mat* pyr_level;
 		pyr_level = &pyramid_cv[i];
 		CV_to_VX_Image(this_level, pyr_level);
 	}
@@ -51,7 +51,7 @@ int CV_to_VX_Pyramid(vx_pyramid pyramid_vx, vector<Mat> pyramid_cv)
 /************************************************************************************************************
 Converting VX matrix into an OpenCV Mat
 *************************************************************************************************************/
-int VX_to_CV_MATRIX(Mat** mat, vx_matrix matrix_vx)
+VX_API_ENTRY int VX_API_CALL VX_to_CV_MATRIX(cv::Mat ** mat, vx_matrix matrix_vx)
 {
 	vx_status status = VX_SUCCESS;
 	vx_size numRows = 0; vx_size numCols = 0; vx_enum type; int Type_CV = 0;
@@ -68,7 +68,7 @@ int VX_to_CV_MATRIX(Mat** mat, vx_matrix matrix_vx)
 		vxAddLogEntry((vx_reference)matrix_vx, VX_ERROR_INVALID_FORMAT, "VX_to_CV_MATRIX ERROR: Matrix type not Supported in this RELEASE\n"); return VX_ERROR_INVALID_FORMAT;
 	}
 
-	Mat * m_cv;	m_cv = new Mat((int)numRows, (int)numCols, Type_CV); vx_size mat_size = numRows * numCols;
+	cv::Mat  * m_cv;	m_cv = new cv::Mat((int)numRows, (int)numCols, Type_CV); vx_size mat_size = numRows * numCols;
 	float *dyn_matrix = new float[mat_size]; int z = 0;
 
 	STATUS_ERROR_CHECK(vxReadMatrix(matrix_vx, (void *)dyn_matrix));
@@ -85,7 +85,7 @@ int VX_to_CV_MATRIX(Mat** mat, vx_matrix matrix_vx)
 /************************************************************************************************************
 Converting VX Image into an OpenCV Mat
 *************************************************************************************************************/
-int VX_to_CV_Image(Mat** mat, vx_image image)
+VX_API_ENTRY int VX_API_CALL VX_to_CV_Image(cv::Mat ** mat, vx_image image)
 {
 	vx_status status = VX_SUCCESS;
 	vx_uint32 width = 0; vx_uint32 height = 0; vx_df_image format = VX_DF_IMAGE_VIRT; int CV_format = 0; vx_size planes = 0;
@@ -104,7 +104,7 @@ int VX_to_CV_Image(Mat** mat, vx_image image)
 		vxAddLogEntry((vx_reference)image, VX_ERROR_INVALID_FORMAT, "VX_to_CV_Image ERROR: Image type not Supported in this RELEASE\n"); return VX_ERROR_INVALID_FORMAT;
 	}
 	
-	Mat * m_cv;	m_cv = new Mat(height, width, CV_format); Mat *pMat = (Mat *)m_cv;
+	cv::Mat  * m_cv;	m_cv = new cv::Mat(height, width, CV_format); cv::Mat  *pMat = (cv::Mat  *)m_cv;
 	vx_rectangle_t rect; rect.start_x = 0; rect.start_y = 0; rect.end_x = width; rect.end_y = height; 
 
 	vx_uint8 *src[4] = { NULL, NULL, NULL, NULL }; vx_uint32 p; void *ptr = NULL;
@@ -132,7 +132,7 @@ int VX_to_CV_Image(Mat** mat, vx_image image)
 /************************************************************************************************************
 Converting CV Image into an OpenVX Image
 *************************************************************************************************************/
-int CV_to_VX_Image(vx_image image, Mat* mat)
+VX_API_ENTRY int VX_API_CALL CV_to_VX_Image(vx_image image, cv::Mat * mat)
 {
 	vx_status status = VX_SUCCESS; vx_uint32 width = 0; vx_uint32 height = 0; vx_size planes = 0;
 
@@ -140,7 +140,7 @@ int CV_to_VX_Image(vx_image image, Mat* mat)
 	STATUS_ERROR_CHECK(vxQueryImage(image, VX_IMAGE_ATTRIBUTE_HEIGHT, &height, sizeof(height)));
 	STATUS_ERROR_CHECK(vxQueryImage(image, VX_IMAGE_ATTRIBUTE_PLANES, &planes, sizeof(planes)));
 
-	Mat *pMat = mat; vx_rectangle_t rect; rect.start_x = 0; rect.start_y = 0; rect.end_x = width; rect.end_y = height; 
+	cv::Mat  *pMat = mat; vx_rectangle_t rect; rect.start_x = 0; rect.start_y = 0; rect.end_x = width; rect.end_y = height; 
 
 	vx_uint8 *src[4] = { NULL, NULL, NULL, NULL }; vx_uint32 p; void *ptr = NULL;
 	vx_imagepatch_addressing_t addr[4] = { 0, 0, 0, 0 }; vx_uint32 y = 0u;
@@ -165,7 +165,7 @@ int CV_to_VX_Image(vx_image image, Mat* mat)
 /************************************************************************************************************
 sort function.
 *************************************************************************************************************/
-bool sortbysize_CV(const KeyPoint &lhs, const KeyPoint &rhs)
+bool sortbysize_CV(const cv::KeyPoint &lhs, const cv::KeyPoint &rhs)
 {
 	return lhs.size < rhs.size;
 }
@@ -173,7 +173,7 @@ bool sortbysize_CV(const KeyPoint &lhs, const KeyPoint &rhs)
 /************************************************************************************************************
 OpenCV Keypoints to OpenVX Keypoints
 *************************************************************************************************************/
-int CV_to_VX_keypoints(vector<KeyPoint> key_points, vx_array array)
+VX_API_ENTRY int VX_API_CALL CV_to_VX_keypoints(vector<cv::KeyPoint> key_points, vx_array array)
 {
 
 	vx_status status = VX_SUCCESS;
@@ -188,7 +188,7 @@ int CV_to_VX_keypoints(vector<KeyPoint> key_points, vx_array array)
 	//sort(key_points.begin(), key_points.end(), sortbysize_CV);
 	vx_size stride = 0; void *base = NULL; vx_size L = 0;
 
-	for (vector<KeyPoint>::const_iterator i = key_points.begin(); i != key_points.end(); ++i)
+	for (vector<cv::KeyPoint>::const_iterator i = key_points.begin(); i != key_points.end(); ++i)
 	{
 		X = key_points[j].pt.x;	Y = key_points[j].pt.y;
 		K_Size = key_points[j].size; K_Angle = key_points[j].angle; K_Response = key_points[j].response;
@@ -215,7 +215,7 @@ int CV_to_VX_keypoints(vector<KeyPoint> key_points, vx_array array)
 /************************************************************************************************************
 OpenCV Points to OpenVX Keypoints
 *************************************************************************************************************/
-int CVPoints2f_to_VX_keypoints(vector<Point2f> key_points, vx_array array)
+VX_API_ENTRY int VX_API_CALL CVPoints2f_to_VX_keypoints(vector<cv::Point2f> key_points, vx_array array)
 {
 	vx_status status = VX_SUCCESS;
 	vector<vx_keypoint_t> Keypoint_VX; float X, Y; int x, y, j = 0;
@@ -255,7 +255,7 @@ int CVPoints2f_to_VX_keypoints(vector<Point2f> key_points, vx_array array)
 /************************************************************************************************************
 OpenCV Descriptors to OpenVX Descriptors
 *************************************************************************************************************/
-int CV_DESP_to_VX_DESP(Mat mat, vx_array array, int stride)
+VX_API_ENTRY int VX_API_CALL CV_DESP_to_VX_DESP(cv::Mat  mat, vx_array array, int stride)
 {
 	vx_status status = VX_SUCCESS; vx_size size = 0;
 

--- a/vx_ext_cv/OpenCV_dilate.cpp
+++ b/vx_ext_cv/OpenCV_dilate.cpp
@@ -154,7 +154,7 @@ static vx_status VX_CALLBACK CV_dilate_Kernel(vx_node node, const vx_reference *
 	vx_scalar ITERATION = (vx_scalar) parameters[5];
 	vx_scalar BORDER = (vx_scalar) parameters[6];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int iteration;
 	int a_x = -1, a_y = -1, border = 4;
 	vx_int32 value = 0;
@@ -170,11 +170,11 @@ static vx_status VX_CALLBACK CV_dilate_Kernel(vx_node node, const vx_reference *
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
-	Mat *kernel;
+	cv::Mat  *kernel;
 	STATUS_ERROR_CHECK(VX_to_CV_MATRIX(&kernel, KERNEL));
-	cv::dilate(*mat, bl, *kernel, Point(a_x, a_y), iteration, border);
+	cv::dilate(*mat, bl, *kernel, cv::Point(a_x, a_y), iteration, border);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_distanceTransform.cpp
+++ b/vx_ext_cv/OpenCV_distanceTransform.cpp
@@ -97,16 +97,16 @@ static vx_status VX_CALLBACK CV_distanceTransform_Kernel(vx_node node, const vx_
 
 	vx_image image_in = (vx_image) parameters[0];
 	vx_image image_out = (vx_image) parameters[1];
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 
-	//Converting VX Image to OpenCV Mat 1
+	//Converting VX Image to OpenCV cv::Mat 1
 	STATUS_ERROR_CHECK(match_vx_image_parameters(image_in, image_out));
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
 	cv::distanceTransform(*mat, bl, CV_DIST_L1, 3, CV_8U); //only CV_DIST_L1 & CV_8U supported in this release
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_divide.cpp
+++ b/vx_ext_cv/OpenCV_divide.cpp
@@ -133,7 +133,7 @@ static vx_status VX_CALLBACK CV_divide_Kernel(vx_node node, const vx_reference *
 	vx_image image_out = (vx_image) parameters[2];
 	vx_scalar SCALE = (vx_scalar) parameters[3];
 	vx_scalar DTYPE = (vx_scalar) parameters[4];
-	Mat *mat_1, *mat_2, bl;
+	cv::Mat  *mat_1, *mat_2, bl;
 
 	vx_int32 value = 0;
 	int dtype;
@@ -153,7 +153,7 @@ static vx_status VX_CALLBACK CV_divide_Kernel(vx_node node, const vx_reference *
 	//Compute using OpenCV
 	cv::divide(*mat_1, *mat_2, bl, scale, dtype);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_erode.cpp
+++ b/vx_ext_cv/OpenCV_erode.cpp
@@ -153,7 +153,7 @@ static vx_status VX_CALLBACK CV_erode_Kernel(vx_node node, const vx_reference *p
 	vx_scalar A_Y = (vx_scalar) parameters[4];
 	vx_scalar ITERATION = (vx_scalar) parameters[5];
 	vx_scalar BORDER = (vx_scalar) parameters[6];
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int iteration;
 	int a_x = -1, a_y = -1, border = 4;
 
@@ -170,11 +170,11 @@ static vx_status VX_CALLBACK CV_erode_Kernel(vx_node node, const vx_reference *p
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
-	Mat *kernel;
+	cv::Mat  *kernel;
 	STATUS_ERROR_CHECK(VX_to_CV_MATRIX(&kernel, KERNEL));
-	cv::erode(*mat, bl, *kernel, Point(a_x, a_y), iteration, border);
+	cv::erode(*mat, bl, *kernel, cv::Point(a_x, a_y), iteration, border);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_fastNlMeansDenoising.cpp
+++ b/vx_ext_cv/OpenCV_fastNlMeansDenoising.cpp
@@ -134,7 +134,7 @@ static vx_status VX_CALLBACK CV_fastNlMeansDenoising_Kernel(vx_node node, const 
 	vx_scalar Template_WS = (vx_scalar) parameters[3];
 	vx_scalar Search_WS = (vx_scalar) parameters[4];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int search_ws, template_ws;
 	float h;
 	vx_float32 value_f = 0;
@@ -152,7 +152,7 @@ static vx_status VX_CALLBACK CV_fastNlMeansDenoising_Kernel(vx_node node, const 
 	//Compute using OpenCV
 	cv::fastNlMeansDenoising(*mat, bl, h, template_ws, search_ws);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_fastNlMeansDenoisingColored.cpp
+++ b/vx_ext_cv/OpenCV_fastNlMeansDenoisingColored.cpp
@@ -146,7 +146,7 @@ static vx_status VX_CALLBACK CV_fastNlMeansDenoisingColored_Kernel(vx_node node,
 	vx_scalar H_COLOR = (vx_scalar) parameters[3];
 	vx_scalar Template_WS = (vx_scalar) parameters[4];
 	vx_scalar Search_WS = (vx_scalar) parameters[5];
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int search_ws, template_ws;
 	float h, h_color;
 	vx_float32 value_f = 0;
@@ -165,7 +165,7 @@ static vx_status VX_CALLBACK CV_fastNlMeansDenoisingColored_Kernel(vx_node node,
 	//Compute using OpenCV
 	cv::fastNlMeansDenoisingColored(*mat, bl, h, h_color, template_ws, search_ws);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_filter2D.cpp
+++ b/vx_ext_cv/OpenCV_filter2D.cpp
@@ -166,7 +166,7 @@ static vx_status VX_CALLBACK CV_filter2D_Kernel(vx_node node, const vx_reference
 	vx_scalar DELTA = (vx_scalar) parameters[6];
 	vx_scalar BORDER = (vx_scalar) parameters[7];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int ddepth, a_x = -1, a_y = -1, border = 4;
 	float delta = 0;
 	vx_int32 value = 0;
@@ -184,14 +184,14 @@ static vx_status VX_CALLBACK CV_filter2D_Kernel(vx_node node, const vx_reference
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
-	Point point;
+	cv::Point point;
 	point.x = a_x;
 	point.y = a_y;
-	Mat *kernel;
+	cv::Mat  *kernel;
 	STATUS_ERROR_CHECK(VX_to_CV_MATRIX(&kernel, KERNEL));
 	cv::filter2D(*mat, bl, ddepth, *kernel, point, delta, border);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_flip.cpp
+++ b/vx_ext_cv/OpenCV_flip.cpp
@@ -109,7 +109,7 @@ static vx_status VX_CALLBACK CV_flip_Kernel(vx_node node, const vx_reference *pa
 	vx_image image_in = (vx_image)parameters[0];
 	vx_image image_out = (vx_image)parameters[1];
 	vx_scalar scalar = (vx_scalar)parameters[2];
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int FlipCode;
 
 	vx_int32 value = 0;
@@ -123,7 +123,7 @@ static vx_status VX_CALLBACK CV_flip_Kernel(vx_node node, const vx_reference *pa
 	//Compute using OpenCV
 	cv::flip(*mat, bl, FlipCode); //output image size should correspond to the right flip code
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_integral.cpp
+++ b/vx_ext_cv/OpenCV_integral.cpp
@@ -110,7 +110,7 @@ static vx_status VX_CALLBACK CV_integral_Kernel(vx_node node, const vx_reference
 	vx_image image_out = (vx_image) parameters[1];
 	vx_scalar scalar = (vx_scalar) parameters[2];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int sdepth;
 	vx_int32 value = 0;
 
@@ -124,7 +124,7 @@ static vx_status VX_CALLBACK CV_integral_Kernel(vx_node node, const vx_reference
 	//Compute using OpenCV
 	cv::integral(*mat, bl, sdepth);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_morphologyEx.cpp
+++ b/vx_ext_cv/OpenCV_morphologyEx.cpp
@@ -166,7 +166,7 @@ static vx_status VX_CALLBACK CV_morphologyEx_Kernel(vx_node node, const vx_refer
 	vx_scalar ITERATION = (vx_scalar) parameters[6];
 	vx_scalar BORDER = (vx_scalar) parameters[7];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int op, iteration;
 	int a_x = -1, a_y = -1, border = 4;
 	vx_int32 value = 0;
@@ -183,11 +183,11 @@ static vx_status VX_CALLBACK CV_morphologyEx_Kernel(vx_node node, const vx_refer
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
-	Mat *kernel;
+	cv::Mat  *kernel;
 	STATUS_ERROR_CHECK(VX_to_CV_MATRIX(&kernel, KERNEL));
-	cv::morphologyEx(*mat, bl, op, *kernel, Point(a_x, a_y), iteration, border);
+	cv::morphologyEx(*mat, bl, op, *kernel, cv::Point(a_x, a_y), iteration, border);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_multiply.cpp
+++ b/vx_ext_cv/OpenCV_multiply.cpp
@@ -134,7 +134,7 @@ static vx_status VX_CALLBACK CV_multiply_Kernel(vx_node node, const vx_reference
 	vx_scalar SCALE = (vx_scalar) parameters[3];
 	vx_scalar DTYPE = (vx_scalar) parameters[4];
 
-	Mat *mat_1, *mat_2, bl;
+	cv::Mat  *mat_1, *mat_2, bl;
 	vx_int32 value = 0;
 	int dtype;
 	vx_float32 value_f = 0;
@@ -144,7 +144,7 @@ static vx_status VX_CALLBACK CV_multiply_Kernel(vx_node node, const vx_reference
 	STATUS_ERROR_CHECK(vxReadScalarValue(SCALE, &value_f));	scale = value_f; 
 	STATUS_ERROR_CHECK(vxReadScalarValue(DTYPE, &value)); dtype = value; 
 
-	//Converting VX Image to OpenCV Mat 1
+	//Converting VX Image to OpenCV cv::Mat 1
 	STATUS_ERROR_CHECK(match_vx_image_parameters(image_1, image_2));
 	STATUS_ERROR_CHECK(match_vx_image_parameters(image_1, image_out)); 
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat_1, image_1));
@@ -153,7 +153,7 @@ static vx_status VX_CALLBACK CV_multiply_Kernel(vx_node node, const vx_reference
 	//Compute using OpenCV
 	cv::multiply(*mat_1, *mat_2, bl, scale, dtype);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_norm.cpp
+++ b/vx_ext_cv/OpenCV_norm.cpp
@@ -100,7 +100,7 @@ static vx_status VX_CALLBACK CV_norm_Kernel(vx_node node, const vx_reference *pa
 	vx_scalar scalar = (vx_scalar) parameters[1];
 	vx_scalar scalar1 = (vx_scalar) parameters[2];
 
-	Mat *mat;
+	cv::Mat  *mat;
 	int Type;
 	vx_int32 value = 0;
 

--- a/vx_ext_cv/OpenCV_orb_compute.cpp
+++ b/vx_ext_cv/OpenCV_orb_compute.cpp
@@ -208,11 +208,11 @@ static vx_status VX_CALLBACK CV_orb_compute_Kernel(vx_node node, const vx_refere
 	vx_scalar SCORETYPE = (vx_scalar) parameters[10];
 	vx_scalar PATCHSIZE = (vx_scalar) parameters[11];
 
-	Mat *mat, *mask_mat, Img;
+	cv::Mat  *mat, *mask_mat, Img;
 	int nFeatures, nLevels, edgeThreshold, firstLevel, WTA_K, scoreType, patchSize;
 	float  ScaleFactor;
-	vector<KeyPoint> key_points;
-	Mat Desp;
+	vector<cv::KeyPoint> key_points;
+	cv::Mat Desp;
 	vx_int32 value = 0;
 	vx_float32 value_F = 0;
 
@@ -231,7 +231,7 @@ static vx_status VX_CALLBACK CV_orb_compute_Kernel(vx_node node, const vx_refere
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mask_mat, mask));
 	
 	//Compute using OpenCV
-	Ptr<Feature2D> orb = ORB::create(nFeatures, ScaleFactor, nLevels, edgeThreshold, firstLevel, WTA_K, scoreType, patchSize);
+	cv::Ptr<cv::Feature2D> orb = cv::ORB::create(nFeatures, ScaleFactor, nLevels, edgeThreshold, firstLevel, WTA_K, scoreType, patchSize);
 	orb->detectAndCompute(*mat, *mask_mat, key_points, Desp);
 
 	//Converting OpenCV Keypoints to OpenVX Keypoints

--- a/vx_ext_cv/OpenCV_pyrdown.cpp
+++ b/vx_ext_cv/OpenCV_pyrdown.cpp
@@ -134,7 +134,7 @@ static vx_status VX_CALLBACK CV_pyrdown_Kernel(vx_node node, const vx_reference 
 	vx_scalar S_height = (vx_scalar) parameters[3];
 	vx_scalar BORDER = (vx_scalar) parameters[4];
 
-	Mat *mat;
+	cv::Mat  *mat;
 	int W, H, border;
 	vx_int32 value = 0;
 
@@ -147,10 +147,10 @@ static vx_status VX_CALLBACK CV_pyrdown_Kernel(vx_node node, const vx_reference 
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
-	Mat bl(Size(W, H), CV_8U);//only CV_8U supported in this release
-	cv::pyrDown(*mat, bl, Size(W, H), border);
+	cv::Mat bl(cv::Size(W, H), CV_8U);//only CV_8U supported in this release
+	cv::pyrDown(*mat, bl, cv::Size(W, H), border);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_pyrup.cpp
+++ b/vx_ext_cv/OpenCV_pyrup.cpp
@@ -134,7 +134,7 @@ static vx_status VX_CALLBACK CV_pyrup_Kernel(vx_node node, const vx_reference *p
 	vx_scalar S_height = (vx_scalar) parameters[3];
 	vx_scalar BORDER = (vx_scalar) parameters[4];
 
-	Mat *mat;
+	cv::Mat  *mat;
 	int W, H, border;
 	vx_int32 value = 0;
 
@@ -147,10 +147,10 @@ static vx_status VX_CALLBACK CV_pyrup_Kernel(vx_node node, const vx_reference *p
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
-	Mat bl(Size(W, H), CV_8U);//Only CV_8U supported in this release
-	cv::pyrUp(*mat, bl, Size(W, H), border);
+	cv::Mat bl(cv::Size(W, H), CV_8U);//Only CV_8U supported in this release
+	cv::pyrUp(*mat, bl, cv::Size(W, H), border);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_resize.cpp
+++ b/vx_ext_cv/OpenCV_resize.cpp
@@ -158,7 +158,7 @@ static vx_status VX_CALLBACK CV_resize_Kernel(vx_node node, const vx_reference *
 	vx_scalar FY = (vx_scalar) parameters[5];
 	vx_scalar INTER = (vx_scalar) parameters[6];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int interpolation;
 	int a_x = -1, a_y = -1;
 	float fx = 0, fy = 0;
@@ -183,9 +183,9 @@ static vx_status VX_CALLBACK CV_resize_Kernel(vx_node node, const vx_reference *
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
-	cv::resize(*mat, bl, Size(a_x, a_y), fx, fy, interpolation);
+	cv::resize(*mat, bl, cv::Size(a_x, a_y), fx, fy, interpolation);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_sepFilter2D.cpp
+++ b/vx_ext_cv/OpenCV_sepFilter2D.cpp
@@ -174,7 +174,7 @@ static vx_status VX_CALLBACK CV_sepFilter2D_Kernel(vx_node node, const vx_refere
 	vx_scalar DELTA = (vx_scalar) parameters[7];
 	vx_scalar BORDER = (vx_scalar) parameters[8];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int ddepth, a_x = -1, a_y = -1, border = 4;
 	float delta = 0;
 	vx_int32 value = 0;
@@ -192,15 +192,15 @@ static vx_status VX_CALLBACK CV_sepFilter2D_Kernel(vx_node node, const vx_refere
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
-	Point point;
+	cv::Point point;
 	point.x = a_x;
 	point.y = a_y;
-	Mat *kernelX, *kernelY;
+	cv::Mat  *kernelX, *kernelY;
 	STATUS_ERROR_CHECK(VX_to_CV_MATRIX(&kernelX, KERNELX));
 	STATUS_ERROR_CHECK(VX_to_CV_MATRIX(&kernelY, KERNELY));
 	cv::sepFilter2D(*mat, bl, ddepth, *kernelX, *kernelY, point, delta, border);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_simple_blob_detector.cpp
+++ b/vx_ext_cv/OpenCV_simple_blob_detector.cpp
@@ -101,15 +101,15 @@ static vx_status VX_CALLBACK CV_simple_blob_detector_Kernel(vx_node node, const 
 	vx_image image_in = (vx_image) parameters[0];
 	vx_array array = (vx_array) parameters[1];
 	vx_image mask = (vx_image) parameters[2];
-	vector<KeyPoint> key_points;
-	Mat *mat, *mask_mat, Img;
+	vector<cv::KeyPoint> key_points;
+	cv::Mat  *mat, *mask_mat, Img;
 
 	//Converting VX Image to OpenCV Mat
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mask_mat, mask));
 
 	//OpenCV Calls to Simple Blob Detector
-	Ptr<Feature2D> simple = SimpleBlobDetector::create();
+	cv::Ptr<cv::Feature2D> simple = cv::SimpleBlobDetector::create();
 	simple->detect(*mat, key_points, *mask_mat);
 
 	//Converting OpenCV Keypoints to OpenVX Keypoints
@@ -414,8 +414,8 @@ static vx_status VX_CALLBACK CV_simple_blob_detector_INITIALIZE_Kernel(vx_node n
 	vx_array array = (vx_array) parameters[1];
 	vx_image mask = (vx_image) parameters[2];
 
-	vector<KeyPoint> key_points;
-	Mat *mat, *mask_mat, Img;
+	vector<cv::KeyPoint> key_points;
+	cv::Mat  *mat, *mask_mat, Img;
 
 	vx_scalar THRESHOLDSTEP = (vx_scalar) parameters[3];
 	vx_scalar MINTHRESHOLD = (vx_scalar) parameters[4];
@@ -498,7 +498,7 @@ static vx_status VX_CALLBACK CV_simple_blob_detector_INITIALIZE_Kernel(vx_node n
 	params.minArea = minArea;
 	params.minConvexity = minConvexity;
 
-	Ptr<Feature2D> simple = SimpleBlobDetector::create(params);
+	cv::Ptr<cv::Feature2D> simple = cv::SimpleBlobDetector::create(params);
 	simple->detect(*mat, key_points, *mask_mat);
 
 	//Converting OpenCV Keypoints to OpenVX Keypoints

--- a/vx_ext_cv/OpenCV_subtract.cpp
+++ b/vx_ext_cv/OpenCV_subtract.cpp
@@ -109,7 +109,7 @@ static vx_status VX_CALLBACK CV_subtract_Kernel(vx_node node, const vx_reference
 	vx_image image_1 = (vx_image) parameters[0];
 	vx_image image_2 = (vx_image) parameters[1];
 	vx_image image_out = (vx_image) parameters[2];
-	Mat *mat_1, *mat_2, bl;
+	cv::Mat  *mat_1, *mat_2, bl;
 
 	//Converting VX Image to OpenCV Mat
 	STATUS_ERROR_CHECK(match_vx_image_parameters(image_1, image_2));
@@ -120,7 +120,7 @@ static vx_status VX_CALLBACK CV_subtract_Kernel(vx_node node, const vx_reference
 	//Compute using OpenCV
 	subtract(*mat_1, *mat_2, bl);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_threshold.cpp
+++ b/vx_ext_cv/OpenCV_threshold.cpp
@@ -134,7 +134,7 @@ static vx_status VX_CALLBACK CV_threshold_Kernel(vx_node node, const vx_referenc
 	vx_scalar MAXVAL = (vx_scalar) parameters[3];
 	vx_scalar TYPE = (vx_scalar) parameters[4];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int type;
 	float thresh, maxVal;
 	vx_float32 value_f = 0;
@@ -152,7 +152,7 @@ static vx_status VX_CALLBACK CV_threshold_Kernel(vx_node node, const vx_referenc
 	//Compute using OpenCV
 	cv::threshold(*mat, bl, thresh, maxVal, type);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_transpose.cpp
+++ b/vx_ext_cv/OpenCV_transpose.cpp
@@ -97,7 +97,7 @@ static vx_status VX_CALLBACK CV_transpose_Kernel(vx_node node, const vx_referenc
 	vx_image image_in = (vx_image) parameters[0];
 	vx_image image_out = (vx_image) parameters[1];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 
 	//Validation
 	vx_uint32 width_in, height_in, width_out, height_out;
@@ -114,7 +114,7 @@ static vx_status VX_CALLBACK CV_transpose_Kernel(vx_node node, const vx_referenc
 	//Compute using OpenCV
 	cv::transpose(*mat, bl);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_warpAffine.cpp
+++ b/vx_ext_cv/OpenCV_warpAffine.cpp
@@ -154,7 +154,7 @@ static vx_status VX_CALLBACK CV_warpAffine_Kernel(vx_node node, const vx_referen
 	vx_scalar FLAGS = (vx_scalar) parameters[5];
 	vx_scalar BORDER = (vx_scalar) parameters[6];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int flags;
 	int a_x = -1, a_y = -1, border = 4;
 	vx_int32 value = 0;
@@ -170,11 +170,11 @@ static vx_status VX_CALLBACK CV_warpAffine_Kernel(vx_node node, const vx_referen
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
-	Mat *M;
+	cv::Mat  *M;
 	STATUS_ERROR_CHECK(VX_to_CV_MATRIX(&M, KERNEL));
-	cv::warpAffine(*mat, bl, *M, Size(a_x, a_y), flags, border);
+	cv::warpAffine(*mat, bl, *M, cv::Size(a_x, a_y), flags, border);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;

--- a/vx_ext_cv/OpenCV_warpPerspective.cpp
+++ b/vx_ext_cv/OpenCV_warpPerspective.cpp
@@ -154,7 +154,7 @@ static vx_status VX_CALLBACK CV_warpPerspective_Kernel(vx_node node, const vx_re
 	vx_scalar FLAGS = (vx_scalar) parameters[5];
 	vx_scalar BORDER = (vx_scalar) parameters[6];
 
-	Mat *mat, bl;
+	cv::Mat  *mat, bl;
 	int flags;
 	int a_x = -1, a_y = -1, border = 4;
 	vx_int32 value = 0;
@@ -170,11 +170,11 @@ static vx_status VX_CALLBACK CV_warpPerspective_Kernel(vx_node node, const vx_re
 	STATUS_ERROR_CHECK(VX_to_CV_Image(&mat, image_in));
 
 	//Compute using OpenCV
-	Mat *M;
+	cv::Mat  *M;
 	STATUS_ERROR_CHECK(VX_to_CV_MATRIX(&M, KERNEL));
-	cv::warpPerspective(*mat, bl, *M, Size(a_x, a_y), flags, border);
+	cv::warpPerspective(*mat, bl, *M, cv::Size(a_x, a_y), flags, border);
 
-	//Converting OpenCV Mat into VX Image
+	//Converting OpenCV cv::Mat into VX Image
 	STATUS_ERROR_CHECK(CV_to_VX_Image(image_out, &bl));
 
 	return status;


### PR DESCRIPTION
Uncomment project vx_ext_cv in CMakeLists.txt
Fix namespace collision between Eigen and OpenCV Mat type in vx_ext_cv by removing "using namespace cv" directive and using fully qualified type-names
Fix resource leak associated with "FILE * fp = fopen(fileName, "rb")", fp was not closed when function returns Error
Added vx_compatibility.h as amdovx-core has updated headers to OpenVX 1.1 