### PR TITLE
LoomSL Linux fix

### DIFF
--- a/vx_loomsl/kernels/initialize_setup_tables.cpp
+++ b/vx_loomsl/kernels/initialize_setup_tables.cpp
@@ -290,7 +290,7 @@ static vx_status VX_CALLBACK calc_lens_distortionwarp_map_opencl_codegen(
 			"	if( gx < vm_width && gy < vm_height){\n"
 			"	camera_z_value_buf += camera_z_value_buf_offs + ((gy*vm_width + gx)<<2);\n"
 			"	valid_pix_map += vm_offs + gy*vm_stride + (gx << 2);\n"
-			"	uint4 valid_pix_out = *(__global uint4 *)(valid_pix_map);\n"
+			"	uint4 valid_pix_out = (uint4) 0;\n"
 			"	for (int camId=0; camId < %d; camId++) {\n"
 			"		__global float * cam_params_cur = (__global float *)(cam_params + camId*128);\n"
 			"		float4 cam_ltrb = *(__global float4*)(cam_params_cur);\n"

--- a/vx_loomsl/kernels/kernels.h
+++ b/vx_loomsl/kernels/kernels.h
@@ -75,7 +75,7 @@ static inline vx_uint32 GetOneBitCount(vx_uint32 a)
 #else
 static inline vx_uint32 GetOneBitPosition(vx_uint32 a)
 {
-	return __builtin_ctz(a);
+	return ((31 - __builtin_clz(a)) < 0) ? 32 : (31 - __builtin_clz(a));
 }
 static inline vx_uint32 GetOneBitCount(vx_uint32 a)
 {


### PR DESCRIPTION
The overlapping rectangles were not being calculated, hence loom turned off exposure compensation and seam find as no overlap was detected. This fix will allow LoomSL to run the full stitch on Linux. 