### PR TITLE
SeamFind Activation for Fish-eye Cameras on Equator

### DIFF
--- a/vx_loomsl/kernels/seam_find.cpp
+++ b/vx_loomsl/kernels/seam_find.cpp
@@ -3592,7 +3592,7 @@ static bool GenerateSeamFindOverlapsForFishEyeOnEquator(
 		for (vx_uint32 camId_2 = camId_1 + 1; camId_2 < numCamera; camId_2++) {
 			vx_float32	pitchDiff = fabsf(camera_par[camId_1].focal.pitch - camera_par[camId_2].focal.pitch);
 			if (pitchDiff <= pitchTolerance){
-				vx_float32 pitchVariance = camera_par[camId_1].focal.pitch - pitchTolerance;
+				vx_float32 pitchVariance = fabsf(camera_par[camId_1].focal.pitch) - pitchTolerance;
 				maxPitchVariance = std::max(maxPitchVariance, pitchVariance);
 			}
 		}


### PR DESCRIPTION
PTgui calibration modulates the Pitch parameters for all the images for
every new calibration, which breaks our assumption that the pitch
tolerance for a equator camera should be less than 5 degrees, as PTgui
calibration produces pitch which ranges 0 - 30 degree for cameras placed
on equator (Example - Z cam S1). This turns off the seam-find.

Current
logic - Looks at the individual pitch values and checks against the
pitch tolerance; if the pitch of all the cameras on the equator is
lesser than the tolerance, then the special case is turned on.

New
Logic proposed - looks at the difference between the max and min pitch
of the all the cameras and compares it to the pitch tolerance, now we
can compensate for pitch modulated by PTgui.