### PR TITLE
Count OpenCL usage within Loom/Fix problems with releasing OpenCL memory in Loom

### DIFF
--- a/vx_loomsl/live_stitch_api.cpp
+++ b/vx_loomsl/live_stitch_api.cpp
@@ -125,7 +125,6 @@ struct ls_context_t {
 	vx_context  context;                        // OpenVX context
 	vx_graph    graphStitch;                    // OpenVX graph for stitching
 	// OpenCL buffer
-	cl_mem      opencl_mem_alloc[32];           // array of all opencl buffers allocated by LOOM
 	vx_size     opencl_mem_alloc_count;         // count number of opencl buffers allocated by LOOM
 	vx_size     opencl_mem_alloc_size;          // count memory of opencl buffers allocated by LOOM
 	vx_size     opencl_mem_release_count;       // count number of opencl buffer released by LOOM
@@ -411,6 +410,7 @@ static vx_status DumpReference(vx_reference ref, const char * fileName)
 	else return VX_ERROR_NOT_SUPPORTED;
 }
 
+//! \Creates an aligned image with a size depending on the input format
 static vx_image CreateAlignedImage(ls_context stitch, vx_uint32 width, vx_uint32 height, vx_uint32 alignpixels, vx_df_image format, vx_enum mem_type)
 {
 	if (mem_type == VX_MEMORY_TYPE_OPENCL){
@@ -450,7 +450,6 @@ static vx_image CreateAlignedImage(ls_context stitch, vx_uint32 width, vx_uint32
 		vx_size size = (addr_in.dim_y + 1) * addr_in.stride_y;
 		cl_int err = CL_SUCCESS;
 		cl_mem clImg = clCreateBuffer(opencl_context, CL_MEM_READ_WRITE, size, NULL, &err);
-		stitch->opencl_mem_alloc[stitch->opencl_mem_alloc_count - stitch->opencl_mem_release_count] = clImg;
 		stitch->opencl_mem_alloc_count++;
 		stitch->opencl_mem_alloc_size += size;
 		if (!clImg || err){
@@ -463,6 +462,28 @@ static vx_image CreateAlignedImage(ls_context stitch, vx_uint32 width, vx_uint32
 	else
 	{
 		return vxCreateImage(stitch->context, width, height, format);
+	}
+}
+
+//! \Release an OpenVX image, if necessary it will free the used OpenCL memory
+static vx_status releaseImage(ls_context stitch, vx_image *input){
+	vx_enum mem_type;
+	ERROR_CHECK_STATUS(vxQueryImage(*input, VX_IMAGE_MEMORY_TYPE, &mem_type, sizeof(mem_type)));
+	if (mem_type == VX_MEMORY_TYPE_OPENCL){
+		cl_mem clImg;
+		ERROR_CHECK_STATUS(vxQueryImage(*input, VX_IMAGE_ATTRIBUTE_AMD_OPENCL_BUFFER, &clImg, sizeof(cl_mem)));
+		clReleaseMemObject(clImg);
+		stitch->opencl_mem_release_count++;
+		vxReleaseImage(input);
+		return VX_SUCCESS;
+	}
+	else if (mem_type == VX_MEMORY_TYPE_NONE){
+		vxReleaseImage(input);
+		return VX_SUCCESS;
+	}
+	else{
+		printf("ERROR: releaseImage: Type not supported\n");
+		return VX_FAILURE;
 	}
 }
 
@@ -1994,7 +2015,6 @@ LIVE_STITCH_API_ENTRY ls_context VX_API_CALL lsCreateContext()
 
 	/////////////////////////////////////////////////////////
 	// Reset OpenCL counter:
-	*stitch->opencl_mem_alloc = { NULL };
 	stitch->opencl_mem_alloc_count = 0;
 	stitch->opencl_mem_alloc_size = 0;
 	stitch->opencl_mem_release_count = 0;
@@ -3089,31 +3109,31 @@ SHARED_PUBLIC vx_status VX_API_CALL lsReleaseContext(ls_context * pStitch)
 		if (stitch->Img_input_rgb) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->Img_input_rgb));
 		if (stitch->Img_output_rgb) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->Img_output_rgb));
 		if (stitch->Img_overlay) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->Img_overlay));
-		if (stitch->Img_overlay_rgb) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->Img_overlay_rgb));
-		if (stitch->Img_overlay_rgba) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->Img_overlay_rgba));
-		if (stitch->warp_output_image) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->warp_output_image));
-		if (stitch->exp_comp_output_image) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->exp_comp_output_image));
-		if (stitch->weight_image) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->weight_image));
-		if (stitch->cam_id_image) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->cam_id_image));
-		if (stitch->group1_image) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->group1_image));
-		if (stitch->group2_image) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->group2_image));
-		if (stitch->expcomp_luma16) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->expcomp_luma16));
-		if (stitch->valid_mask_image) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->valid_mask_image));
-		if (stitch->warp_luma_image) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->warp_luma_image));
-		if (stitch->sobel_magnitude_s16_image) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->sobel_magnitude_s16_image));
-		if (stitch->sobelx_image) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->sobelx_image));
-		if (stitch->sobely_image) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->sobely_image));
-		if (stitch->sobel_magnitude_image) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->sobel_magnitude_image));
-		if (stitch->sobel_phase_image) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->sobel_phase_image));
-		if (stitch->seamfind_weight_image) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->seamfind_weight_image));
-		if (stitch->blend_mask_image) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->blend_mask_image));
+		if (stitch->Img_overlay_rgb) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->Img_overlay_rgb));
+		if (stitch->Img_overlay_rgba) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->Img_overlay_rgba));
+		if (stitch->warp_output_image) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->warp_output_image));
+		if (stitch->exp_comp_output_image) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->exp_comp_output_image));
+		if (stitch->weight_image) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->weight_image));
+		if (stitch->cam_id_image) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->cam_id_image));
+		if (stitch->group1_image) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->group1_image));
+		if (stitch->group2_image) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->group2_image));
+		if (stitch->expcomp_luma16) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->expcomp_luma16));
+		if (stitch->valid_mask_image) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->valid_mask_image));
+		if (stitch->warp_luma_image) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->warp_luma_image));
+		if (stitch->sobel_magnitude_s16_image) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->sobel_magnitude_s16_image));
+		if (stitch->sobelx_image) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->sobelx_image));
+		if (stitch->sobely_image) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->sobely_image));
+		if (stitch->sobel_magnitude_image) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->sobel_magnitude_image));
+		if (stitch->sobel_phase_image) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->sobel_phase_image));
+		if (stitch->seamfind_weight_image) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->seamfind_weight_image));
+		if (stitch->blend_mask_image) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->blend_mask_image));
 		if (stitch->blend_offsets) ERROR_CHECK_STATUS_(vxReleaseArray(&stitch->blend_offsets));
 		if (stitch->chroma_key_input_img) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->chroma_key_input_img));
 		if (stitch->chroma_key_mask_img) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->chroma_key_mask_img));
-		if (stitch->chroma_key_dilate_mask_img) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->chroma_key_dilate_mask_img));
-		if (stitch->chroma_key_erode_mask_img) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->chroma_key_erode_mask_img));
-		if (stitch->chroma_key_input_RGB_img) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->chroma_key_input_RGB_img));
-		if (stitch->noiseFilterInput_image) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->noiseFilterInput_image));
+		if (stitch->chroma_key_dilate_mask_img) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->chroma_key_dilate_mask_img));
+		if (stitch->chroma_key_erode_mask_img) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->chroma_key_erode_mask_img));
+		if (stitch->chroma_key_input_RGB_img) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->chroma_key_input_RGB_img));
+		if (stitch->noiseFilterInput_image) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->noiseFilterInput_image));
 
 		// release scalar objects
 		if (stitch->current_frame) ERROR_CHECK_STATUS_(vxReleaseScalar(&stitch->current_frame));
@@ -3181,10 +3201,10 @@ SHARED_PUBLIC vx_status VX_API_CALL lsReleaseContext(ls_context * pStitch)
 				if (stitch->pStitchMultiband[i].UpscaleSubtractNode)ERROR_CHECK_STATUS_(vxReleaseNode(&stitch->pStitchMultiband[i].UpscaleSubtractNode));
 				if (stitch->pStitchMultiband[i].UpscaleAddNode)ERROR_CHECK_STATUS_(vxReleaseNode(&stitch->pStitchMultiband[i].UpscaleAddNode));
 				if (stitch->pStitchMultiband[i].LaplacianReconNode)ERROR_CHECK_STATUS_(vxReleaseNode(&stitch->pStitchMultiband[i].LaplacianReconNode));
-				if (stitch->pStitchMultiband[i].DstPyrImgGaussian) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->pStitchMultiband[i].DstPyrImgGaussian));
-				if (stitch->pStitchMultiband[i].WeightPyrImgGaussian) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->pStitchMultiband[i].WeightPyrImgGaussian));
-				if (stitch->pStitchMultiband[i].DstPyrImgLaplacian) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->pStitchMultiband[i].DstPyrImgLaplacian));
-				if (stitch->pStitchMultiband[i].DstPyrImgLaplacianRec) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->pStitchMultiband[i].DstPyrImgLaplacianRec));
+				if (stitch->pStitchMultiband[i].DstPyrImgGaussian) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->pStitchMultiband[i].DstPyrImgGaussian));
+				if (stitch->pStitchMultiband[i].WeightPyrImgGaussian) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->pStitchMultiband[i].WeightPyrImgGaussian));
+				if (stitch->pStitchMultiband[i].DstPyrImgLaplacian) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->pStitchMultiband[i].DstPyrImgLaplacian));
+				if (stitch->pStitchMultiband[i].DstPyrImgLaplacianRec) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->pStitchMultiband[i].DstPyrImgLaplacianRec));
 			}
 			delete[] stitch->pStitchMultiband;
 			delete[] stitch->multibandBlendOffsetIntoBuffer;
@@ -3207,10 +3227,10 @@ SHARED_PUBLIC vx_status VX_API_CALL lsReleaseContext(ls_context * pStitch)
 		// release tiled image elements
 		if (stitch->num_encode_sections > 1){
 			for (vx_uint32 i = 0; i < stitch->num_encode_sections; i++){
-				if (stitch->encode_src_rgb_imgs[i]) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->encode_src_rgb_imgs[i]));
-				if (stitch->encode_dst_imgs[i]) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->encode_dst_imgs[i]));
+				if (stitch->encode_src_rgb_imgs[i]) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->encode_src_rgb_imgs[i]));
+				if (stitch->encode_dst_imgs[i]) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->encode_dst_imgs[i]));
 				if (stitch->encode_color_convert_nodes[i]) ERROR_CHECK_STATUS_(vxReleaseNode(&stitch->encode_color_convert_nodes[i]));
-				if (stitch->encodetileOutput[i])ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->encodetileOutput[i]));
+				if (stitch->encodetileOutput[i])ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->encodetileOutput[i]));
 			}
 		}
 
@@ -3219,10 +3239,10 @@ SHARED_PUBLIC vx_status VX_API_CALL lsReleaseContext(ls_context * pStitch)
 			if (stitch->stitchInitData){
 				if (stitch->stitchInitData->CameraParamsArr) ERROR_CHECK_STATUS_(vxReleaseArray(&stitch->stitchInitData->CameraParamsArr));
 				if (stitch->stitchInitData->CameraZBuffArr) ERROR_CHECK_STATUS_(vxReleaseArray(&stitch->stitchInitData->CameraZBuffArr));
-				if (stitch->stitchInitData->DefaultCamMap) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->stitchInitData->DefaultCamMap));
-				if (stitch->stitchInitData->ValidPixelMap) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->stitchInitData->ValidPixelMap));
-				if (stitch->stitchInitData->PaddedPixMap) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->stitchInitData->PaddedPixMap));
-				if (stitch->stitchInitData->SrcCoordMap) ERROR_CHECK_STATUS_(vxReleaseImage(&stitch->stitchInitData->SrcCoordMap));
+				if (stitch->stitchInitData->DefaultCamMap) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->stitchInitData->DefaultCamMap));
+				if (stitch->stitchInitData->ValidPixelMap) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->stitchInitData->ValidPixelMap));
+				if (stitch->stitchInitData->PaddedPixMap) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->stitchInitData->PaddedPixMap));
+				if (stitch->stitchInitData->SrcCoordMap) ERROR_CHECK_STATUS_(releaseImage(stitch, &stitch->stitchInitData->SrcCoordMap));
 				if (stitch->stitchInitData->calc_warp_maps_node) ERROR_CHECK_STATUS_(vxReleaseNode(&stitch->stitchInitData->calc_warp_maps_node));
 				if (stitch->stitchInitData->calc_default_idx_node) ERROR_CHECK_STATUS_(vxReleaseNode(&stitch->stitchInitData->calc_default_idx_node));
 				if (stitch->stitchInitData->pad_dilate_node) ERROR_CHECK_STATUS_(vxReleaseNode(&stitch->stitchInitData->pad_dilate_node));
@@ -3244,15 +3264,6 @@ SHARED_PUBLIC vx_status VX_API_CALL lsReleaseContext(ls_context * pStitch)
 		if (stitch->validPixelOverlayMap) { delete[] stitch->validPixelOverlayMap; stitch->validPixelOverlayMap = nullptr; }
 		if (stitch->overlayIndexTmpBuf) { delete[] stitch->overlayIndexTmpBuf; stitch->overlayIndexTmpBuf = nullptr; }
 		if (stitch->overlayIndexBuf) { delete[] stitch->overlayIndexBuf; stitch->overlayIndexBuf = nullptr; }
-
-		// release openCL buffers
-		for (int i = 0; i < 32; i++){
-			if (stitch->opencl_mem_alloc[i] != NULL){
-				clReleaseMemObject(stitch->opencl_mem_alloc[i]);
-				stitch->opencl_mem_alloc[i] = NULL;
-				stitch->opencl_mem_release_count++;
-			}
-		}
 
 		// debug aux dumps
 		if (stitch->loomioAuxDumpFile) {


### PR DESCRIPTION
- Added three variables to count OpenCL usage in Loom: opencl_mem_alloc_count, opencl_mem_alloc_size, opencl_mem_release_count (Names are the same as used within OpenVX for the same purpose)
- Added output to print the counts
- Counted wherever necessary

- Released all cl_mem objects at the end
- If reinit is disabled, release init buffers as soon as possible