### PR TITLE
Changed data entries for high resolution

### DIFF
--- a/vx_loomsl/kernels/exp_comp.cpp
+++ b/vx_loomsl/kernels/exp_comp.cpp
@@ -298,9 +298,6 @@ vx_status Compute_StitchExpCompCalcEntry(vx_rectangle_t *pOverlap_roi, vx_array 
 						ExpOut.end_x = ((x + 127) > x2) ? (x2 - x) : 127;
 						ExpOut.end_y = ((y + 31) > y2) ? (y2 - y) : 31;
 						ExpOut.camId1 = j;
-						ExpOut.camId2 = 0x1F;
-						ExpOut.camId3 = 0x1F;
-						ExpOut.camId4 = 0x1F;
 						ERROR_CHECK_STATUS(vxAddArrayItems(ExpCompOut, 1, &ExpOut, sizeof(ExpOut)));
 					}
 				}

--- a/vx_loomsl/kernels/exposure_compensation.cpp
+++ b/vx_loomsl/kernels/exposure_compensation.cpp
@@ -250,11 +250,11 @@ static vx_status VX_CALLBACK exposure_comp_calcErrorFn_opencl_codegen(
 		"	int ly = get_local_id(1);\n"
 		"	int lid = mad24(ly, (int)get_local_size(0), lx);\n"
 		"   sumI[lid] = 0; sumJ[lid] = 0;\n"
-		"	bool isValid = ((lx<<3) < (int)(offs.s1&0x7f)) && (ly*2 < (int)((offs.s1>>7)&0x1f));\n"
+		"	bool isValid = ((lx<<3) < (int)((offs.s1>>16)&0xff)) && (ly*2 < (int)((offs.s1>>24)&0xff));\n"
 		"	if (isValid) {\n"
-		"		int   gx = (lx<<3) + ((offs.s0 >> 5) & 0x3FFF);\n"
-		"		int   gy = (ly<<1) + (offs.s0 >> 19);\n"
-		"		uint2 cam_id = (uint2)((offs.s0 & 0x1f), ((offs.s1>>12) & 0x1f));\n";
+		"		int   gx = (lx<<3) + ((offs.s0) & 0xffff);\n"
+		"		int   gy = (ly<<1) + ((offs.s0 >> 16) & 0xffff);\n"
+		"		uint2 cam_id = (uint2)((offs.s1 & 0xff), ((offs.s1>>8) & 0xff));\n";
 	if (mask_image){
 		opencl_kernel_code +=
 			"		uint4 maskSrc; \n"
@@ -1711,13 +1711,13 @@ static vx_status VX_CALLBACK exposure_comp_calcRGBErrorFn_opencl_codegen(
 			"   sumI[lid] = (uint4)0; sumJ[lid] = (uint4)0;\n";
 	}
 	opencl_kernel_code +=
-		"	bool isValid = ((lx<<3) < (int)(offs.s1&0x7f)) && (ly*2 < (int)((offs.s1>>7)&0x1f));\n"
+		"	bool isValid = ((lx<<3) < (int)((offs.s1 >> 16)&0xff)) && (ly*2 < (int)((offs.s1>>24)&0xff));\n"
 		"	if (isValid) {\n"
 		"		global uint *pI, *pJ;\n"
 		"		uint4 Isum4, Jsum4;\n"
-		"		int   gx = (lx<<3) + ((offs.s0 >> 5) & 0x3FFF);\n"
-		"		int   gy = (ly<<1) + (offs.s0 >> 19);\n"
-		"		uint2 cam_id = (uint2)((offs.s0 & 0x1f), ((offs.s1>>12) & 0x1f));\n";
+		"		int   gx = (lx<<3) + ((offs.s0) & 0xffff);\n"
+		"		int   gy = (ly<<1) + ((offs.s0 >> 16) & 0xffff);\n"
+		"		uint2 cam_id = (uint2)((offs.s1 & 0xff), ((offs.s1>>8) & 0xff));\n";
 	if (mask_image){
 		opencl_kernel_code +=
 			"		pWt_buf += pWt_offs + mad24(gy, (int)pWt_stride, gx);\n"
@@ -2392,9 +2392,6 @@ vx_status GenerateExpCompBuffers(
 									overlapEntry.end_x = xe - xs - 1;
 									overlapEntry.end_y = ye - ys - 1;
 									overlapEntry.camId1 = j;
-									overlapEntry.camId2 = 0x1F;
-									overlapEntry.camId3 = 0x1F;
-									overlapEntry.camId4 = 0x1F;
 									overlapTable[overlapEntryCount] = overlapEntry;
 								}
 								overlapEntryCount++;

--- a/vx_loomsl/kernels/exposure_compensation.h
+++ b/vx_loomsl/kernels/exposure_compensation.h
@@ -40,15 +40,12 @@ typedef struct {
 //////////////////////////////////////////////////////////////////////
 //! \brief The overlap pixel entry.
 typedef struct {
-	vx_uint32 camId0  :  5; // destination buffer/camera ID
-	vx_uint32 start_x : 14; // destination start pixel x-coordinate
-	vx_uint32 start_y : 13; // destination start pixel y-coordinate
-	vx_uint32 end_x   :  7; // ending pixel x-coordinate within the 128x32 block
-	vx_uint32 end_y   :  5; // ending pixel y-coordinate within the 128x32 block
-	vx_uint32 camId1  :  5; // values [0..30] overlapping cameraId; 31 indicates invalid cameraId
-	vx_uint32 camId2  :  5; // values [0..30] overlapping cameraId; 31 indicates invalid cameraId
-	vx_uint32 camId3  :  5; // values [0..30] overlapping cameraId; 31 indicates invalid cameraId
-	vx_uint32 camId4  :  5; // values [0..30] overlapping cameraId; 31 indicates invalid cameraId
+	vx_uint32 start_x : 16; // destination start pixel x-coordinate
+	vx_uint32 start_y : 16; // destination start pixel y-coordinate	
+	vx_uint32 camId0  :  8; // destination buffer/camera ID
+	vx_uint32 camId1  :  8; // values [0..30] overlapping cameraId; 31 indicates invalid cameraId
+	vx_uint32 end_x   :  8; // ending pixel x-coordinate within the 128x32 block
+	vx_uint32 end_y   :  8; // ending pixel y-coordinate within the 128x32 block
 } StitchOverlapPixelEntry;
 
 //////////////////////////////////////////////////////////////////////

--- a/vx_loomsl/kernels/multiband_blender.cpp
+++ b/vx_loomsl/kernels/multiband_blender.cpp
@@ -231,8 +231,8 @@ static vx_status VX_CALLBACK multiband_blend_opencl_codegen(
 		"	int grp_id = get_global_id(0)>>4, lx = get_local_id(0), ly = get_local_id(1);\n"
 		"	if (grp_id < pG_num) {\n"
 		"	uint2 offs = ((__global uint2 *)(pG_buf+pG_offs))[grp_id+arr_offs];\n"
-		"	uint camera_id = offs.x & 0x1f; uint gx = (lx<<2) + ((offs.x >> 5) & 0x3FFF); uint gy = ly + (offs.x >> 19);\n"
-		"	bool outputValid = (lx*4 <= (offs.y & 0xFF)) && (ly <= ((offs.y >> 8) & 0xFF));\n"
+		"	uint camera_id = offs.s1 & 0x3f; uint gx = (lx<<2) + ((offs.s0) & 0xffff); uint gy = ly + (offs.s0 >> 16);\n"
+		"	bool outputValid = (lx*4 <= ((offs.s1 >> 6) & 0x3F)) && (ly <= ((offs.y >> 12) & 0xf));\n"
 		"	op_buf  += op_offset + mad24(gy, op_stride, gx*6);\n"
 		"	ip_buf += (camera_id * ip_stride*%d);\n"
 		"	wt_buf += (camera_id * wt_stride*%d);\n"
@@ -469,8 +469,8 @@ vx_uint32 GenerateBlendBuffers(
 					entry->skip_x = (x < start_x) ? (start_x - x) : 0;
 					entry->skip_y = 0;
 					// check if the workgroup is processing border pixels, store it in high bits of skip_y
-					entry->skip_y |= ((!x) | (((x + 64) << level) >= (vx_int32)eqrWidth)) << 6;
-					entry->skip_y |= ((!y) | (((y + 16) << level) >= (vx_int32)eqrHeight)) << 7;
+					entry->boarder  = ((!x) | (((x + 64) << level) >= (vx_int32)eqrWidth));
+					entry->boarder |= ((!y) | (((y + 16) << level) >= (vx_int32)eqrHeight)) << 1;
 				}
 			}
 		}

--- a/vx_loomsl/kernels/multiband_blender.h
+++ b/vx_loomsl/kernels/multiband_blender.h
@@ -44,13 +44,14 @@ typedef struct{
 }StitchMultibandData;
 
 typedef struct {
-	vx_uint32 camId   :  5; // destination buffer/camera ID
-	vx_uint32 dstX    : 14; // destination pixel x-coordinate (integer)
-	vx_uint32 dstY    : 13; // destination pixel y-coordinate (integer)
-	vx_uint32 last_x  :  8; // ending pixel x-coordinate within the 64x16 block
-	vx_uint32 last_y  :  8; // ending pixel y-coordinate within the 64x16 block
+	vx_uint32 dstX    : 16; // destination pixel x-coordinate (integer)
+	vx_uint32 dstY    : 16; // destination pixel y-coordinate (integer)
+	vx_uint32 camId   :  6; // destination buffer/camera ID
+	vx_uint32 last_x  :  6; // ending pixel x-coordinate within the 64x16 block
+	vx_uint32 last_y  :  4; // ending pixel y-coordinate within the 64x16 block
 	vx_uint32 skip_x  :  8; // starting pixel x-coordinate within the 64x16 block
-	vx_uint32 skip_y  :  8; // starting pixel y-coordinate within the 64x16 block
+	vx_uint32 skip_y  :  6; // starting pixel y-coordinate within the 64x16 block
+	vx_uint32 boarder :  2; // defines if block is at image boarder
 } StitchBlendValidEntry;
 
 //////////////////////////////////////////////////////////////////////

--- a/vx_loomsl/kernels/pyramid_scale.cpp
+++ b/vx_loomsl/kernels/pyramid_scale.cpp
@@ -340,31 +340,31 @@ static vx_status VX_CALLBACK half_scale_gaussian_opencl_codegen(
 	}
 	opencl_kernel_code +=
 		"    uint2 wgInfo = *(__global uint2 * ) valid_pix_buf;\n"
-		"    int camId = wgInfo.s0 & 0x1F;\n"
-		"    int gx = (wgInfo.s0 >> 5) & 0x3FFF;\n"
-		"    int gy = (wgInfo.s0 >> 19) & 0x1FFF;\n"
-		"    int border = (wgInfo.s1 >> 30)&0x3;\n";
+		"    int camId = wgInfo.s1 & 0x3F;\n"
+		"    int gx = (wgInfo.s0) & 0xffff;\n"
+		"    int gy = (wgInfo.s0 >> 16) & 0xffff;\n"
+		"    int border = (wgInfo.s1 >> 30) & 0x3;\n";
 	if (input_format == VX_DF_IMAGE_RGB4_AMD) {
 		opencl_kernel_code +=
 			"    bool outputValid = true;\n"
 			"    if(grp_id & 0x1){\n"
 			"      gy+=8;\n"
-			"      outputValid = (outputValid) && ((ly+8) <= ((wgInfo.s1 >> 8) & 0xFF)) ? true : false; \n"
+			"      outputValid = (outputValid) && ((ly+8) <= ((wgInfo.s1 >> 12) & 0xF)) ? true : false; \n"
 			"    }\n"
 			"    else{\n"
-			"      outputValid = (outputValid) && ((ly) <= ((wgInfo.s1 >> 8) & 0xFF)) ? true : false; \n"
+			"      outputValid = (outputValid) && ((ly) <= ((wgInfo.s1 >> 12) & 0xF)) ? true : false; \n"
 			"    }\n"
 			"    if(grp_id & 0x2){\n"
 			"      gx+=32;\n"
-			"      outputValid = (((lx>>1)+8) <= ((wgInfo.s1 & 0xFF) >> 2)) && (outputValid) ? true : false; \n"
+			"      outputValid = (((lx>>1)+8) <= (((wgInfo.s1 >> 6) & 0x3F) >> 2)) && (outputValid) ? true : false; \n"
 			"    }\n"
 			"    else{\n"
-			"      outputValid = ((lx>>1) <= ((wgInfo.s1 & 0xFF) >> 2)) && (outputValid) ? true : false; \n"
+			"      outputValid = ((lx>>1) <= (((wgInfo.s1 >> 6) & 0x3F) >> 2)) && (outputValid) ? true : false; \n"
 			"    }\n";
 	}
 	else{
 		opencl_kernel_code +=
-			"    bool outputValid = (lx <= ((wgInfo.s1 & 0xFF) >> 2)) && (ly <= ((wgInfo.s1 >> 8) & 0xFF)) ? true : false;\n";
+			"    bool outputValid = (lx <= (((wgInfo.s1 >> 6) & 0x3F) >> 2)) && (ly <= ((wgInfo.s1 >> 12) & 0xF)) ? true : false;\n";
 	}
 	if (input_format == VX_DF_IMAGE_U8) {
 		if (output_format == VX_DF_IMAGE_U8){
@@ -1273,11 +1273,11 @@ static vx_status VX_CALLBACK upscale_gaussian_subtract_opencl_codegen(
 		"	if (grp_id < pG_num) {\n"
 		"	int size_x = get_local_size(0) - 1; \n"
 		"	uint2 offs = ((__global uint2 *)pG_buf)[grp_id];\n"
-		"	uint camera_id = offs.x & 0x1f; int gx = (lx<<2) + ((offs.x >> 5) & 0x3FFF); int gy = (offs.x >> 19);\n"
+		"	uint camera_id = offs.s1 & 0x3f; int gx = (lx<<2) + ((offs.s0) & 0xffff); int gy = (offs.x >> 16);\n"
 		"	if (!get_group_id(1) | (get_group_id(1) && (gy+8 < %d))) {\n"
 		"	gy += (ly<<1);\n"
-		"	bool outputValid = (lx*4 <= (offs.y & 0xFF)) && (ly*2 <= ((offs.y >> 8)&0xFF));\n"
-		"	int border = (offs.y >> 30) & 0x3;\n"
+		"	bool outputValid = (lx*4 <= ((offs.s1>>6) & 0x3f)) && (ly*2 <= ((offs.s1 >> 12)&0xf));\n"
+		"	int border = (offs.s1 >> 30) & 0x3;\n"
 		"	int ybound = %d;\n"
 		"	op_buf  += op_offset + mad24(gy, (int)op_stride, gx*6);\n"
 		"	ip1_buf += ip1_offset + (camera_id * ip1_stride*%d);\n"
@@ -1930,9 +1930,9 @@ static vx_status VX_CALLBACK upscale_gaussian_add_opencl_codegen(
 		"	if (grp_id < pG_num) {\n"
 		"		int size_x = get_local_size(0) - 1; \n"
 		"		uint2 offs = ((__global uint2 *)pG_buf)[grp_id];\n"
-		"		uint camera_id = offs.x & 0x1f; uint gx = (lx<<3) + ((offs.x >> 5) & 0x3FFF); uint gy = ly*2 + (offs.x >> 19);\n"
-		"	    bool outputValid = (lx*8 <= (offs.y & 0xFF)) && (ly*2 <= ((offs.y >> 8) & 0xFF));\n"
-		"		int border = (offs.y >> 30) & 0x3;\n"
+		"		uint camera_id = offs.s1 & 0x3f; uint gx = (lx<<3) + ((offs.s0) & 0xffff); uint gy = ly*2 + (offs.s0 >> 16);\n"
+		"	    bool outputValid = (lx*8 <= ((offs.s1 >> 6) & 0x3f)) && (ly*2 <= ((offs.s1 >> 12) & 0xf));\n"
+		"		int border = (offs.s1 >> 30) & 0x3;\n"
 		"		int height1 = %d;\n"
 		"		ip_buf += ip_offset + mad24(gy, ip_stride, gx*6);\n"
 		"		ip_buf += (camera_id * ip_stride*%d);\n"

--- a/vx_loomsl/kernels/warp.cpp
+++ b/vx_loomsl/kernels/warp.cpp
@@ -1235,7 +1235,7 @@ std::string get_warp_valid_info_4pixels(){
 		"    uint pixelEntry = *(__global uint*) valid_pix_buf;\n"
 		"    if(pixelEntry == 0xffffffff) return;\n"
 		"    uint4 map = *(__global uint4 *) warp_remap_buf;\n"
-		"    uint camera_id = pixelEntry & 0x1f; uint op_x = (pixelEntry >> 8) & 0x7ff; uint op_y = (pixelEntry >> 19) & 0x1fff;\n";
+		"    uint camera_id = pixelEntry & 0x1f; uint op_x = (pixelEntry >> 6) & 0xfff; uint op_y = (pixelEntry >> 18) & 0x3fff;\n";
 	return output;
 }
 std::string get_warp_valid_info_2pixels(){
@@ -1246,7 +1246,7 @@ std::string get_warp_valid_info_2pixels(){
 		"    uint pixelEntry = *(__global uint*) valid_pix_buf;\n"
 		"    if(pixelEntry == 0xffffffff) return;\n"
 		"    uint4 map = *(__global uint4 *) warp_remap_buf;\n"
-		"    uint camera_id = pixelEntry & 0x1f; uint op_x = (pixelEntry >> 8) & 0x7ff; uint op_y = (pixelEntry >> 19) & 0x1fff;\n";
+		"    uint camera_id = pixelEntry & 0x1f; uint op_x = (pixelEntry >> 6) & 0xfff; uint op_y = (pixelEntry >> 18) & 0x3fff;\n";
 	return output;
 }
 

--- a/vx_loomsl/kernels/warp.h
+++ b/vx_loomsl/kernels/warp.h
@@ -39,10 +39,9 @@ enum {
 //  For dummy entries in the buffer for alignment to 32 items, the invalid items shall be (vx_uint32)0xFFFFFFFF
 typedef struct {
 	vx_uint32 camId     :  5; // destination buffer/camera ID
-	vx_uint32 reserved0 :  2; // reserved (shall be zero)
 	vx_uint32 allValid  :  1; // all 8 consecutive pixels are valid
-	vx_uint32 dstX      : 11; // destination pixel x-coordinate/8 (integer)
-	vx_uint32 dstY      : 13; // destination pixel y-coordinate   (integer)
+	vx_uint32 dstX      : 12; // destination pixel x-coordinate/8 (integer)
+	vx_uint32 dstY      : 14; // destination pixel y-coordinate   (integer)
 } StitchValidPixelEntry;
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Changed some data entries to support a higher resolution:
- Exposure Compensation - OverlapPixelEntry: Only needs to support 2 cameras, therefore removed additional camera ids; More bits for destination coordinates
- Multiband - BlendValidEntry: Added bits for boarder (already used before but not defined properly); more bits for CamID and destination coordinates
- Warp - ValidPixelEntry: More bits for destination coordinates, therefore removed reserved bits. 