### PR TITLE
convert_image_to_tensor take 5 args

### DIFF
--- a/vx_nn/README.md
+++ b/vx_nn/README.md
@@ -91,9 +91,11 @@ import vx_nn
 
 data input  = image:32,32,RGB2
 data output = tensor:4,{32,32,3,1},VX_TYPE_FLOAT32,0
-data flip = scalar:UINT32,1
+data a = scalar:FLOAT32,0.0
+data b = scalar:FLOAT32,0.0
+data reverse_channel_order = scalar:BOOL,0
 read input input.png
-node com.amd.nn_extension.convert_image_to_tensor input output flip
+node com.amd.nn_extension.convert_image_to_tensor input output a b reverse_channel_order
 write output input.f32
 
 ```


### PR DESCRIPTION
convert_image_to_tensor take **5 args**.
`input`  : image (RGB or U8)
`output`: tensor `FLOAT32`
`a`        : `FLOAT32` 
`b`        : `FLOAT32`
`reverse_channel_order`: `BOOL` RGB to BGR
```
r = a * unpack0(rgb) + b
g = a * unpack1(rgb) + b
b = a * unpack2(rgb) + b
```
